### PR TITLE
ci(#1): GitHub PR용 Claude Code Action 리뷰봇 도입

### DIFF
--- a/.github/workflows/claude-assistant.yml
+++ b/.github/workflows/claude-assistant.yml
@@ -1,0 +1,37 @@
+name: Claude Assistant
+
+# 이슈·PR 코멘트에서 @claude 멘션 시 응답한다.
+# issue_comment / pull_request_review_comment 는 base 브랜치 컨텍스트로 실행되므로
+# fork PR 에서도 시크릿에 접근 가능 — 그래서 아래 author_association 가드로
+# 쓰기 권한 보유자(OWNER/MEMBER/COLLABORATOR)의 멘션만 트리거한다.
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+jobs:
+  claude-response:
+    if: |
+      contains(github.event.comment.body, '@claude') &&
+      (github.event.comment.author_association == 'OWNER' ||
+       github.event.comment.author_association == 'MEMBER' ||
+       github.event.comment.author_association == 'COLLABORATOR')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_args: |
+            --max-turns 10
+            --model claude-sonnet-5

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,43 @@
+name: Claude Code Review
+
+# PR 자동 리뷰. 공개레포이므로 pull_request 트리거를 쓴다 —
+# GitHub은 fork PR 실행에서 시크릿(ANTHROPIC_API_KEY)을 withhold 하므로 키가 유출되지 않는다.
+# 아래 if 가드로 동일 레포발 PR(브랜치 PR)에서만 리뷰를 돌려, fork PR 은 조용히 건너뛴다.
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  claude-review:
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: read
+      id-token: write
+      actions: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            이 PR 을 이 저장소의 리뷰 컨벤션에 맞춰 리뷰한다.
+            - code-reviewer 에이전트로 버그·품질·유지보수성 리뷰
+            - security-audit 에이전트로 시크릿 노출·인증 누락 등 보안 점검
+            - .claude/rules/ 의 우선순위 티어를 기준으로 P0(즉시 중단)/P1(PR 차단)/P2(권장)로
+              분류하고, P0·P1 위반을 최우선으로 지적한다
+            - AGENTS.md/CLAUDE.md 의 규약(이슈 연결, 테스트 동반, 브랜치 전략 등) 준수 여부 확인
+
+            리뷰 결과는 PR 코멘트로 남긴다.
+            Repository: ${{ github.repository }}
+            PR: #${{ github.event.pull_request.number }}
+          claude_args: |
+            --max-turns 8
+            --model claude-sonnet-5
+          track_progress: true
+          use_sticky_comment: true


### PR DESCRIPTION
## 개요

GitHub PR에 공식 Claude Code Action(`anthropics/claude-code-action@v1`) 리뷰봇을
도입한다. 기존 `srope/review-bot`은 GitLab 시스템훅 전용이라 GitHub PR에 붙지 않아,
GitHub에서 작업할 때 리뷰 공백을 메운다.

## 변경

- **`.github/workflows/claude-code-review.yml`** — PR open/synchronize 시 자동 리뷰.
  프롬프트가 이 레포의 `code-reviewer`·`security-audit` 에이전트와 `.claude/rules/`
  P0/P1/P2 티어를 참조하도록 구성. 결과는 sticky 코멘트로.
- **`.github/workflows/claude-assistant.yml`** — 이슈/PR 코멘트 `@claude` 멘션 응답.

## 공개레포 보안

- 자동 리뷰: `pull_request` 트리거(→ GitHub이 fork PR에서 시크릿 withhold) +
  `head.repo.full_name == github.repository` 가드 → fork PR은 조용히 skip, 시크릿 무노출.
- 어시스턴트: `issue_comment`는 base 컨텍스트라 시크릿이 살아있으므로
  `author_association`(OWNER/MEMBER/COLLABORATOR) 가드로 쓰기권한자 멘션만 트리거.

## 머지 후 수동 설정 (레포 오너)

1. `gh secret set ANTHROPIC_API_KEY --repo LeeYudok/claude-scaffold`
2. Claude GitHub App 설치: https://github.com/apps/claude → 이 레포 선택
3. Settings → Actions → General → Workflow permissions: Read and write

## 비용 메모

리뷰/응답 모델은 `claude-sonnet-5`(비용 절감). 필요 시 `claude_args`의 `--model`을
`claude-opus-4-8`로 상향.

Closes #1

Made with [Orca](https://github.com/stablyai/orca) 🐋
