### PR TITLE
docs: Chinese/Japanese READMEs + CI secret guard

### DIFF
--- a/.github/workflows/claude-assistant.yml
+++ b/.github/workflows/claude-assistant.yml
@@ -12,7 +12,9 @@ on:
 
 jobs:
   claude-response:
+    # vars.CLAUDE_REVIEW_ENABLED 미설정 레포(시크릿 없음)에서는 실행하지 않는다
     if: |
+      vars.CLAUDE_REVIEW_ENABLED == 'true' &&
       contains(github.event.comment.body, '@claude') &&
       (github.event.comment.author_association == 'OWNER' ||
        github.event.comment.author_association == 'MEMBER' ||

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -9,7 +9,8 @@ on:
 
 jobs:
   claude-review:
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    # 같은 레포 PR + API 키 시크릿이 설정된 경우에만 — 포크 PR 과 시크릿 미설정 레포에서 실패 방지
+    if: github.event.pull_request.head.repo.full_name == github.repository && vars.CLAUDE_REVIEW_ENABLED == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/README.en.md
+++ b/README.en.md
@@ -1,6 +1,6 @@
 # claude-scaffold
 
-[한국어](README.md) | English
+[한국어](README.md) | English | [简体中文](README.zh.md) | [日本語](README.ja.md)
 
 [![tests](https://github.com/leeyudok/claude-scaffold/actions/workflows/test.yml/badge.svg)](https://github.com/leeyudok/claude-scaffold/actions/workflows/test.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,265 @@
+# claude-scaffold
+
+[한국어](README.md) | [English](README.en.md) | [简体中文](README.zh.md) | 日本語
+
+[![tests](https://github.com/leeyudok/claude-scaffold/actions/workflows/test.yml/badge.svg)](https://github.com/leeyudok/claude-scaffold/actions/workflows/test.yml)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+
+**フレームワークではありません — Claude Code のためのミニマルな fork-and-fill ブートストラップです**。
+ルール階層を**強制**します: P0(即時停止) / P1(PRブロック) / P2(レビュー指摘)。スタックプリセットは
+単一の pre-commit ゲートに合成されます。
+
+![デモ: ワンコマンドのブートストラップ、生成された .claude/ ツリー、ステージングされた .env をブロックする pre-commit ゲート](docs/assets/demo.gif)
+
+_30秒デモ: コマンド1つ → 記入済みの `.claude/` → ゲートがシークレットのコミットをブロック。`vhs docs/assets/demo.tape` で再現できます。_
+
+## Quickstart
+
+```bash
+# クローン不要、コマンド1つで
+curl -fsSL https://raw.githubusercontent.com/leeyudok/claude-scaffold/main/bin/claude-scaffold.sh | bash -s -- --stack nextjs --yes
+
+# またはローカルクローンから(オプション省略時は対話的にプロンプト)
+git clone https://github.com/leeyudok/claude-scaffold.git
+claude-scaffold/bin/claude-scaffold.sh /path/to/new-repo --forge github --stack nextjs,bun --name my-app
+```
+
+記入済みの `.claude/` ディレクトリ(エージェント、スキル、フック、paths スコープの
+ルール、メモリ)、プロジェクトの頭脳となる `AGENTS.md`、そして合成された単一の pre-commit
+ゲートが手に入ります — すべて完全にあなたが所有するプレーンなファイルです。全オプションは
+[Usage](#usage-1--script) を参照してください。
+
+## 何が手に入るか — 初心者向け
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="docs/assets/overview-dark.svg">
+  <img alt="コマンド1つ → 自分が所有する .claude/(エージェント、スキル、コマンド、ルール、フック、メモリ、AGENTS.md)→ ステージングされた .env・壊れたビルド・lint 失敗をブロックする強制ゲート" src="docs/assets/overview-light.svg">
+</picture>
+
+インストールの1分後には、Claude はルールを心得たチームメイトのように振る舞います。
+プロンプトに不慣れでも大丈夫です:
+
+- **ワークフローがデフォルトになる**: 「ログイン機能を作って」と言えば、Claude が
+  イシュー → ブランチ → 実装 → テスト → PR/MR を自律的に進めます(`/fix-issue`;
+  `/sdlc-cycle` は役割分離された3つのエージェントで無人サイクルを実行)。
+- **ミスは機構でブロックされる**: `.env`/シークレットのコミット、壊れたビルドや
+  型エラー、新規 JSP スクリプトレットは pre-commit フックが止め、
+  複雑度 15 を超える関数にはフラグが立ちます — Claude が忘れても捕捉するゲートです。
+- **ワンショットコマンド**: `/review`(コードレビュー + セキュリティ監査)、`/status`、
+  `/knowledge-graph`(ドキュメントリンクチェッカー)、`/sonar`。
+- **要件の鍛え込み、2つから選択**: **`grill-me`**(同梱)は仕様を複数ラウンドで
+  問い詰めます。**superpowers の `brainstorming`**
+  ([obra/superpowers](https://github.com/obra/superpowers)、別プラグイン)は
+  アイデアの発散と収束を協働で行います。両方インストールしていれば、タスクごとに
+  使い分けます — 方向性が決まった機能は grill、白紙の状態からは brainstorm。
+- **セッションをまたいで生き残るメモリ**: プロジェクトの学びが
+  `.claude/memory/` 配下に蓄積され、次のセッションで自動ロードされ、チームで共有されます。
+- **自己進化**: skill-evolve/agent-evolve が失敗のフィードバックからスキル/エージェント
+  定義を書き換えます — 使えば使うほど良くなります。
+- **チーム/マルチセッションでも安全**: セッションごとの git worktree 分離が
+  デフォルトなので、並行作業が互いを踏み荒らすことはありません。
+
+## なぜ claude-scaffold か
+
+大規模なインストール型フレームワークやエージェント/スキルのカタログと違い、claude-scaffold は
+ランタイムも、プラグインシステムも、同期を保つべき中央レジストリも持ちません —
+これは `.claude/` ディレクトリのスケルトンと少数のスタックプリセットであり、
+一度リポジトリにコピーしたらあとは完全にあなたのものです。後からアップグレードすべきものは
+何もありません: フォークし、プレースホルダーを埋め、不要なものを削除すれば、
+結果はリポジトリ内の他のコードと同じくバージョン管理下のプレーンなファイルです。
+
+- **建前ではなく強制** — P0/P1/P2 階層はフック(pre-commit ゲート、deny ルール、
+  CC 警告)に配線されており、散文で書かれているだけではありません。
+- **paths スコープのルール** — ルールはマッチするファイルを触っている間だけロードされるため、
+  すべての規約を先頭ロードせずコンテキストがスリムに保たれます。
+- **自己改善** — `skill-evolve`/`agent-evolve` が実際のミスから「Learned warnings」を
+  スキルとエージェントに追記します。
+- **テスト済み** — ブートストラップスクリプトには bats のリグレッションスイートが同梱され、
+  knowledge-graph リンクチェッカーがドキュメントをゲートします。
+
+## 中身
+
+```
+.claude/
+  agents/
+    security-audit.md   12項目の P0/P1 セキュリティ grep スキャン
+    db-migration.md      DDL 安全性チェック + ロールバック SQL 生成
+    sdlc-developer.md    最小スコープ実装エージェント(SDLC 役割分離)
+    sdlc-tester.md        AC/TC テスト作成エージェント
+    sdlc-verifier.md      パイプライン実行 + レポートエージェント
+    agent-evolve.md       自己改善メタエージェント — 実行フィードバックから agents/*.md を洗練
+  commands/
+    sonar.md             SonarQube 分析(CE タスクポーリング、sqp_/squ_ トークン処理)
+    sdlc-cycle.md         5段階 SDLC 自動化
+    knowledge-graph.md    .claude ナレッジグラフ再生成 + リンク切れチェック
+  hooks/
+    pre-commit.sh         pre-commit ゲートのスケルトン(スタックパーシャルの挿入点)
+    post-edit-format.sh   PostToolUse(Edit|Write) → 自動フォーマット
+    post-test-notify.sh   PostToolUse(Bash, *test*) → ターミナル通知
+    stop-memory-remind.sh Stop フック → セッションごとに1回のメモリリマインダー
+    cc-check.py            PostToolUse(Bash, git commit) → CC > 15 なら警告
+  memory/
+    MEMORY.md              auto-memory インデックス(SSOT)
+    README.md               メモリのタイプ/利用ルール
+  rules/
+    common.md               P0/P1/P2 優先度階層 + 共通ワークフロー(常時ロード)
+    security.md              シークレット/認証 P0 + ロックアウト/管理者シーディング規則(paths スコープ)
+    testing.md               機能ごとにテスト、mock 優先ユニット、ユーザー視点アサーション
+    data.md                  データスクリプト規則 — 一括ステージング禁止、エンコーディング明示
+    README.md                paths スコープロード + ルール作成原則
+  skills/
+    skill-evolve/            自己改善メタスキル(「Learned warnings」パターン)
+    status/                   マルチスタック状態チェック
+    review/                   code-reviewer + security-audit ラッパー
+    memory-factcheck/         メモリのファクトチェック — 主張をコード/DB/イシューと照合し、古いものを修正
+    security-precheck/        監査前セキュリティスイープ → イシュー化 → 並列修正
+  workflows/
+    rules-audit.js           保存型 Workflow の例 — scan/verify/repair、マージは人間ゲート
+  scripts/
+    knowledge_graph.py       .claude エコシステムグラフ + --check リンク切れゲート
+  settings.json               フック配線 + デフォルト deny ルール
+AGENTS.md                 プロジェクトの頭脳 — ルール SSOT(P0/P1/P2 + ワークフロー)
+CLAUDE.md                 @AGENTS.md へのポインタ(Claude Code)
+GEMINI.md                 @AGENTS.md へのポインタ(Gemini CLI)
+presets/                  プリセット断片(コピー上書きモデル)
+  forge-github/           GitHub forge — gh、PR、`Closes #N` 自動クローズ
+  forge-gitlab/           GitLab forge — glab、MR、`Closes #N` 自動クローズ(マージ後に確認)
+  nextjs/ bun/ ...        スタック別断片(rules + pre-commit.partial.sh)
+  lang-en/                英語オーバーレイ(base/forge-*/stacks/*)— 後述の `--lang` を参照
+bin/                      claude-scaffold.sh ブートストラップスクリプト
+tests/                    ブートストラップスクリプト用 bats リグレッションスイート
+```
+
+## スタックプリセット
+
+| プリセット | ルールファイル | pre-commit ゲート |
+|--------|-----------|-----------------|
+| `nextjs` | nextjs.md (paths: app/**, components/**) | `tsc --noEmit` |
+| `springboot` | springboot.md (paths: src/main/java/**) | `./gradlew build` |
+| `javaweb` | javaweb.md (paths: src/main/java/**, **/*.jsp) | maven/gradle/ant compile (自動検出) |
+| `bun` | bun.md (paths: **/*.ts) | `bunx tsc --noEmit` |
+| `python` | python.md (paths: **/*.py) | `ruff check` + `mypy` |
+| `go` | go.md (paths: **/*.go) | `go build ./...` + `vet` + `golangci-lint` |
+| `rust` | rust.md (paths: src/**/*.rs, **/*.rs) | `cargo check` + `clippy` |
+| `android` | android.md (paths: **/*.kt) | `./gradlew ktlintCheck detekt` |
+| `ops` | ops.md (paths: Dockerfile, docker-compose*, quadlet/**, ansible/**) | — |
+
+## Forge プリセット (`--forge`)
+
+利用する forge のイシュー/PR ワークフローを注入します。スタックプリセットより先にマージされます。
+
+| プリセット | CLI | PR/MR | イシュークローズ |
+|--------|-----|-------|-------------|
+| `github` (デフォルト) | `gh` | PR | `Closes #N` によりマージ時に**自動クローズ** |
+| `gitlab` | `glab` | MR | `Closes #N` の自動クローズは動作する — マージ後に確認し、open のままの場合のみ手動 |
+
+注入されるファイル: `.claude/rules/forge.md`(常時ロード)に加え、
+`.claude/commands/fix-issue.md` と `sdlc-cycle.md` の forge 別バリアント(ベースを上書き)。
+ベースファイルは forge 非依存のまま("issue / PR·MR")です。
+
+## 言語 (`--lang`)
+
+ベースツリー(エージェント、ルール、スキル、コマンド、`AGENTS.md`、フック/settings の
+メッセージ)は**デフォルトで韓国語**です(#36 での反転 — 韓国語が単一の真実源で、
+英語は翻訳オーバーレイ)。`--lang en` は英訳を最後に重ねます — ベースコピー、
+forge プリセット、スタックプリセットの後に適用されるため、同じファイルを
+`presets/lang-en/base` + `presets/lang-en/forge-<forge>` + `presets/lang-en/stacks/<stack>`
+の内容で上書きします。
+
+```bash
+claude-scaffold/bin/claude-scaffold.sh /path/to/new-repo --lang en --forge github --stack bun
+```
+
+`.claude/hooks/pre-commit.sh` は `--lang` によるオーバーレイの対象外です
+(スタックパーシャルが挿入されるファイルであり、メッセージは単一言語、コードは
+言語の影響を受けません)。`--update` は韓国語のベースのみを更新します。英語
+オーバーレイを再適用したい場合は、その上で `--lang en` を付けて再実行してください。
+
+## Usage 1 — script
+
+```bash
+git clone https://github.com/leeyudok/claude-scaffold.git
+# --forge のデフォルトは github。GitLab リポジトリには --forge gitlab を使う
+claude-scaffold/bin/claude-scaffold.sh /path/to/new-repo --forge github --stack nextjs,bun --name my-app
+```
+
+`--forge`/`--stack`/`--name` を省略すると対話モードで実行され、スクリプトが
+プロンプトを表示します(forge のデフォルトは github)。
+
+### オプション
+
+| オプション | 説明 |
+|---|---|
+| `<target-dir>` | 対象ディレクトリ。デフォルト `.` |
+| `--forge <forge>` | `github`(デフォルト)または `gitlab` |
+| `--lang <lang>` | `ko`(デフォルト)または `en` |
+| `--stack <list>` | カンマ区切りのスタックプリセット。省略時は対話的にプロンプト |
+| `--name <name>` | `{{PROJECT_NAME}}` の置換値。デフォルトは対象ディレクトリ名 |
+| `--yes` | 対話プロンプトをスキップ(非対話モード) |
+| `--update` | ブートストラップ済みプロジェクトのベースファイルを更新(後述) |
+
+### リモートワンコマンドインストール(クローン不要)
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/leeyudok/claude-scaffold/main/bin/claude-scaffold.sh | bash -s -- --stack nextjs --yes
+```
+
+スクリプトはローカルチェックアウトから実行されていないこと(パイプ実行など)を検知すると、
+`CLAUDE_SCAFFOLD_REPO` の tarball(デフォルト: `github.com/leeyudok/claude-scaffold`、
+環境変数で上書き可)を一時ディレクトリにダウンロードし、テンプレートソースとして
+使用します。ブランチ/タグの固定は `CLAUDE_SCAFFOLD_REF`(デフォルト `main`)で行います。
+
+### ベースの更新 — `--update`
+
+ブートストラップ済みプロジェクトに最新のベースファイル(`.claude/`、`AGENTS.md`、
+`CLAUDE.md`、`GEMINI.md`)を適用します。
+
+```bash
+claude-scaffold/bin/claude-scaffold.sh --update /path/to/existing-repo
+```
+
+- `.claude/hooks/pre-commit.sh` は常にスキップされます — スタックパーシャルが
+  挿入済みのため、手動マージが必要です。
+- その他のベースファイルは、内容が同一ならスキップされます。差分がある場合は
+  既存ファイルを保持し、新バージョンを `<file>.new` として書き出します
+  (プレースホルダー置換は `.new` ファイルにも適用されます)。
+- 最後に追加 / 更新保留 / スキップ / 変更なしのファイルのサマリーが出力されます —
+  `.new` ファイルを `diff` で確認し、手動で適用してください。
+
+## Usage 2 — GitLab テンプレート
+
+新規プロジェクト作成時にこの設定を自動適用するには、
+**[docs/GITLAB_TEMPLATE.md](docs/GITLAB_TEMPLATE.md)** を参照してください。
+
+> 注: このワークフローはセルフホストの GitLab インスタンスを前提とします。**GitLab CE** では
+> ネイティブのカスタムプロジェクトテンプレートは Premium 機能のため利用できません —
+> 代わりに **Import by URL + `bin/claude-scaffold.sh`**、または**スクリプト単体**を使ってください。
+> 作成/インポート後に `bin/claude-scaffold.sh .` を1回実行すると、選択したスタックの適用、
+> プレースホルダー置換、`bin/`/`presets/`/`docs/superpowers/` のセルフクリーンが行われます。
+
+## プレースホルダー置換
+
+| トークン | 値 |
+|---|---|
+| `{{PROJECT_NAME}}` | `--name` の値、または対象ディレクトリ名 |
+| `{{JAVA_VERSION}}` | `1.8`(springboot プリセットのデフォルト) |
+
+## 主要パターン
+
+- **P0/P1/P2 優先度階層**: `common.md` + `AGENTS.md` で定義。P0 = セキュリティ/シークレット/データ破壊、例外なし。
+- **SDLC 役割分離**: developer/tester/verifier エージェント + `/sdlc-cycle` 自動化コマンド。
+- **skill-evolve / agent-evolve**: ミスから「Learned warnings」を追記する自己改善パターン。`skill-evolve` は `.claude/skills/*.md`、`agent-evolve` は `.claude/agents/*.md` が対象。
+- **メモリ SSOT**: `.claude/memory/`(システムデフォルトパスは使用しない)。タイプ接頭辞: `project_`/`feedback_`/`reference_`/`user_`。
+- **paths スコープのルール**: frontmatter の `paths:` により、マッチするファイルの作業中のみルールを自動ロード。
+- **マルチエージェント分離**: 並列サブエージェントが同一ファイルを同時に触る可能性がある場合は `isolation: "worktree"` を使用。
+
+## コントリビュート
+
+ワークフローは [CONTRIBUTING.md](CONTRIBUTING.md)、スタックプリセットの形式は
+[docs/PRESET_SPEC.md](docs/PRESET_SPEC.md) を参照してください。
+初めての方は [`good first issue`](https://github.com/LeeYudok/claude-scaffold/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) から始めるのがおすすめです —
+レイアウトが完全にテンプレート化されているため、新しいスタックプリセットの追加が最も取り組みやすい課題です。
+
+## ライセンス
+
+MIT — [LICENSE](LICENSE) を参照してください。

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # claude-scaffold
 
-한국어 | [English](README.en.md)
+한국어 | [English](README.en.md) | [简体中文](README.zh.md) | [日本語](README.ja.md)
 
 [![tests](https://github.com/leeyudok/claude-scaffold/actions/workflows/test.yml/badge.svg)](https://github.com/leeyudok/claude-scaffold/actions/workflows/test.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)

--- a/README.zh.md
+++ b/README.zh.md
@@ -1,0 +1,263 @@
+# claude-scaffold
+
+[한국어](README.md) | [English](README.en.md) | 简体中文 | [日本語](README.ja.md)
+
+[![tests](https://github.com/leeyudok/claude-scaffold/actions/workflows/test.yml/badge.svg)](https://github.com/leeyudok/claude-scaffold/actions/workflows/test.yml)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+
+**这不是一个框架，而是一套极简的、fork 后按需填充的 Claude Code 引导脚手架**，
+自带**强制执行**的规则分级：P0（立即中止）/ P1（阻断 PR）/ P2（评审提示）。各技术栈预设
+会组合进单一的 pre-commit 门禁。
+
+![演示：一条命令完成引导、生成的 .claude/ 目录树，以及 pre-commit 门禁拦截暂存的 .env](docs/assets/demo.gif)
+
+_30 秒演示：一条命令 → 填充完毕的 `.claude/` → 门禁拦截了一次泄露密钥的提交。可用 `vhs docs/assets/demo.tape` 复现。_
+
+## Quickstart
+
+```bash
+# 一条命令，无需 clone
+curl -fsSL https://raw.githubusercontent.com/leeyudok/claude-scaffold/main/bin/claude-scaffold.sh | bash -s -- --stack nextjs --yes
+
+# 或从本地克隆运行（省略选项时会进入交互式提问）
+git clone https://github.com/leeyudok/claude-scaffold.git
+claude-scaffold/bin/claude-scaffold.sh /path/to/new-repo --forge github --stack nextjs,bun --name my-app
+```
+
+你将得到一个填充完毕的 `.claude/` 目录（agents、skills、hooks、按路径作用域加载的
+规则、memory）、一份作为项目大脑的 `AGENTS.md`，以及一个组合而成的 pre-commit
+门禁——全部是完全归你所有的普通文件。完整选项见 [Usage](#usage-1--脚本)。
+
+## 你会得到什么 — 写给新手
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="docs/assets/overview-dark.svg">
+  <img alt="一条命令 → 一个归你所有的 .claude/（agents、skills、commands、rules、hooks、memory、AGENTS.md）→ 强制门禁拦截暂存的 .env、失败的构建和不通过的 lint" src="docs/assets/overview-light.svg">
+</picture>
+
+安装一分钟后，Claude 的表现就像一位熟知团队规则的同事。即使你刚接触
+prompt 编写也没关系：
+
+- **工作流即默认行为**：只要说"实现登录功能"，Claude 就会自行遵循
+  issue → 分支 → 实现 → 测试 → PR/MR 的流程（`/fix-issue`；
+  `/sdlc-cycle` 由三个职责分离的 agent 无人值守地跑完一个完整周期）。
+- **错误由机制拦截**：提交 `.env`/密钥、构建失败/类型错误、新增 JSP
+  scriptlet 都会被 pre-commit 钩子拦下，认知复杂度超过 15 的函数会被
+  标记——即使 Claude 忘了规则，门禁也能兜底。
+- **一键命令**：`/review`（代码评审 + 安全审计）、`/status`、
+  `/knowledge-graph`（文档链接检查器）、`/sonar`。
+- **需求打磨，两种方式任选**：**`grill-me`**（内置）对规格说明进行多轮
+  拷问；**superpowers 的 `brainstorming`**
+  （[obra/superpowers](https://github.com/obra/superpowers)，独立插件）
+  以协作方式发散再收敛想法。两者都装好后按任务选用——已有方向的功能
+  用 grill，一张白纸则用 brainstorm。
+- **跨会话留存的记忆**：项目经验持续沉淀在 `.claude/memory/` 下，
+  下次会话自动加载，并与团队共享。
+- **自我进化**：skill-evolve/agent-evolve 会根据失败反馈重写 skill/agent
+  定义——用得越多越好用。
+- **团队/多会话安全**：默认按会话隔离 git worktree，并行工作互不
+  踩踏。
+
+## 为什么选择 claude-scaffold
+
+与大型可安装框架或 agent/skill 目录不同，claude-scaffold 不附带运行时、
+不带插件系统、也没有需要保持同步的中心化 registry——它只是一个 `.claude/`
+目录骨架加上几个技术栈预设，复制进仓库一次之后就完全归你所有。日后没有
+任何东西需要升级：fork 它、填好占位符、删掉不需要的部分，最终得到的就是
+和仓库里其他代码一样纳入版本控制的普通文件。
+
+- **强制执行，而非纸上谈兵** —— P0/P1/P2 分级接入了钩子机制
+  （pre-commit 门禁、deny 规则、CC 警告），不只是写在文档里。
+- **按路径作用域加载的规则** —— 规则只在你触碰匹配文件时才加载，
+  上下文保持精简，而不是一开始就灌入全部约定。
+- **自我改进** —— `skill-evolve`/`agent-evolve` 会把真实错误提炼成
+  "Learned warnings" 追加到 skill 和 agent 里。
+- **经过测试** —— 引导脚本附带 bats 回归测试套件，知识图谱链接
+  检查器为文档把关。
+
+## 内含什么
+
+```
+.claude/
+  agents/
+    security-audit.md   12 项 P0/P1 安全 grep 扫描
+    db-migration.md      DDL 安全检查 + 回滚 SQL 生成
+    sdlc-developer.md    最小范围实现 agent（SDLC 角色分离）
+    sdlc-tester.md        AC/TC 测试编写 agent
+    sdlc-verifier.md      流水线执行 + 报告 agent
+    agent-evolve.md       自我改进元 agent —— 根据运行反馈打磨 agents/*.md
+  commands/
+    sonar.md             SonarQube 分析（CE 任务轮询、sqp_/squ_ 令牌处理）
+    sdlc-cycle.md         5 阶段 SDLC 自动化
+    knowledge-graph.md    重新生成 .claude 知识图谱 + 断链检查
+  hooks/
+    pre-commit.sh         pre-commit 门禁骨架（技术栈片段的接入点）
+    post-edit-format.sh   PostToolUse(Edit|Write) → 自动格式化
+    post-test-notify.sh   PostToolUse(Bash, *test*) → 终端通知
+    stop-memory-remind.sh Stop 钩子 → 每会话一次的记忆提醒
+    cc-check.py            PostToolUse(Bash, git commit) → CC > 15 时告警
+  memory/
+    MEMORY.md              auto-memory 索引（SSOT）
+    README.md               记忆类型/使用规则
+  rules/
+    common.md               P0/P1/P2 优先级分级 + 通用工作流（始终加载）
+    security.md              密钥/认证 P0 + 锁定/管理员初始化规则（按路径作用域）
+    testing.md               每功能一测试、mock 优先的单元测试、用户视角断言
+    data.md                  数据脚本规则 —— 禁止批量暂存、显式指定编码
+    README.md                按路径作用域加载 + 规则编写原则
+  skills/
+    skill-evolve/            自我改进元 skill（"Learned warnings" 模式）
+    status/                   多技术栈状态检查
+    review/                   code-reviewer + security-audit 封装
+    memory-factcheck/         记忆事实核查 —— 对照代码/DB/issue 验证并修正过期内容
+    security-precheck/        审计前安全排查 → 拆分 issue → 并行修复
+  workflows/
+    rules-audit.js           存储式 Workflow 示例 —— 扫描/验证/修复，合并由人工把关
+  scripts/
+    knowledge_graph.py       .claude 生态图谱 + --check 断链门禁
+  settings.json               钩子接线 + 默认 deny 规则
+AGENTS.md                 项目大脑 —— 规则 SSOT（P0/P1/P2 + 工作流）
+CLAUDE.md                 指向 @AGENTS.md 的指针（Claude Code）
+GEMINI.md                 指向 @AGENTS.md 的指针（Gemini CLI）
+presets/                  预设片段（复制覆盖模型）
+  forge-github/           GitHub forge —— gh、PR、`Closes #N` 自动关闭
+  forge-gitlab/           GitLab forge —— glab、MR、`Closes #N` 自动关闭（合并后需确认）
+  nextjs/ bun/ ...        各技术栈片段（规则 + pre-commit.partial.sh）
+  lang-en/                英文覆盖层（base/forge-*/stacks/*）—— 见下文 `--lang`
+bin/                      claude-scaffold.sh 引导脚本
+tests/                    引导脚本的 bats 回归测试套件
+```
+
+## 技术栈预设
+
+| 预设 | 规则文件 | pre-commit 门禁 |
+|--------|-----------|-----------------|
+| `nextjs` | nextjs.md (paths: app/**, components/**) | `tsc --noEmit` |
+| `springboot` | springboot.md (paths: src/main/java/**) | `./gradlew build` |
+| `javaweb` | javaweb.md (paths: src/main/java/**, **/*.jsp) | maven/gradle/ant compile（自动检测） |
+| `bun` | bun.md (paths: **/*.ts) | `bunx tsc --noEmit` |
+| `python` | python.md (paths: **/*.py) | `ruff check` + `mypy` |
+| `go` | go.md (paths: **/*.go) | `go build ./...` + `vet` + `golangci-lint` |
+| `rust` | rust.md (paths: src/**/*.rs, **/*.rs) | `cargo check` + `clippy` |
+| `android` | android.md (paths: **/*.kt) | `./gradlew ktlintCheck detekt` |
+| `ops` | ops.md (paths: Dockerfile, docker-compose*, quadlet/**, ansible/**) | — |
+
+## Forge 预设（`--forge`）
+
+注入与你所用 forge 匹配的 issue/PR 工作流。在技术栈预设之前合并。
+
+| 预设 | CLI | PR/MR | issue 关闭 |
+|--------|-----|-------|-------------|
+| `github`（默认） | `gh` | PR | 合并时通过 `Closes #N` **自动关闭** |
+| `gitlab` | `glab` | MR | `Closes #N` 自动关闭有效 —— 合并后需确认，仍处于 open 时才手动关闭 |
+
+注入的文件：`.claude/rules/forge.md`（始终加载），以及
+`.claude/commands/fix-issue.md` 和 `sdlc-cycle.md` 的 forge 变体（覆盖基础版本）。
+基础文件保持 forge 中立（"issue / PR·MR"）。
+
+## 语言（`--lang`）
+
+基础目录树（agents、rules、skills、commands、`AGENTS.md`、钩子/settings
+消息）**默认为韩语**（#36 反转——韩语是事实来源，英语是翻译出的覆盖层）。
+`--lang en` 会把英文翻译叠加在最上层，且最后应用——在基础复制、forge 预设、
+技术栈预设之后——用 `presets/lang-en/base` +
+`presets/lang-en/forge-<forge>` + `presets/lang-en/stacks/<stack>` 的内容
+覆盖同名文件。
+
+```bash
+claude-scaffold/bin/claude-scaffold.sh /path/to/new-repo --lang en --forge github --stack bun
+```
+
+`.claude/hooks/pre-commit.sh` 永远不会被 `--lang` 覆盖（它是技术栈片段
+拼接进去的文件——消息只有单一语言，代码不受语言影响）。`--update`
+只刷新韩语基础文件；若需要重新应用英文覆盖层，请在其后再带
+`--lang en` 运行一次。
+
+## Usage 1 — 脚本
+
+```bash
+git clone https://github.com/leeyudok/claude-scaffold.git
+# --forge 默认为 github；GitLab 仓库请用 --forge gitlab
+claude-scaffold/bin/claude-scaffold.sh /path/to/new-repo --forge github --stack nextjs,bun --name my-app
+```
+
+省略 `--forge`/`--stack`/`--name` 即进入交互模式——脚本会依次询问
+（forge 默认为 github）。
+
+### 选项
+
+| 选项 | 说明 |
+|---|---|
+| `<target-dir>` | 目标目录。默认 `.` |
+| `--forge <forge>` | `github`（默认）或 `gitlab` |
+| `--lang <lang>` | `ko`（默认）或 `en` |
+| `--stack <list>` | 逗号分隔的技术栈预设列表。省略时进入交互式提问 |
+| `--name <name>` | `{{PROJECT_NAME}}` 的替换值。默认 = 目标目录名 |
+| `--yes` | 跳过交互式提问（非交互模式） |
+| `--update` | 刷新已引导项目的基础文件（见下文） |
+
+### 远程一键安装（无需 clone）
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/leeyudok/claude-scaffold/main/bin/claude-scaffold.sh | bash -s -- --stack nextjs --yes
+```
+
+当脚本检测到自己并非从本地检出运行时（例如管道执行），会将
+`CLAUDE_SCAFFOLD_REPO` 的 tarball（默认：
+`github.com/leeyudok/claude-scaffold`，可通过环境变量覆盖）下载到临时目录，
+并将其作为模板来源。用 `CLAUDE_SCAFFOLD_REF` 固定分支/标签
+（默认 `main`）。
+
+### 更新基础文件 — `--update`
+
+将最新的基础文件（`.claude/`、`AGENTS.md`、`CLAUDE.md`、
+`GEMINI.md`）应用到已完成引导的项目。
+
+```bash
+claude-scaffold/bin/claude-scaffold.sh --update /path/to/existing-repo
+```
+
+- `.claude/hooks/pre-commit.sh` 始终被跳过——技术栈片段已被拼接
+  进去，需要手动合并。
+- 其他基础文件内容相同时跳过；有差异时保留现有文件，新版本写为
+  `<file>.new`（占位符替换同样作用于 `.new` 文件）。
+- 结束时打印新增 / 待更新 / 跳过 / 未变更文件的汇总——用 `diff`
+  查看 `.new` 文件后手动应用。
+
+## Usage 2 — GitLab 模板
+
+若想在创建新项目时自动应用这套配置，
+请参阅 **[docs/GITLAB_TEMPLATE.md](docs/GITLAB_TEMPLATE.md)**。
+
+> 注意：该工作流假定使用自托管 GitLab 实例。在 **GitLab CE** 上，
+> 原生的自定义项目模板属于 Premium 功能、不可用——
+> 请改用 **Import by URL + `bin/claude-scaffold.sh`** 或**仅用脚本**。
+> 创建/导入后运行一次 `bin/claude-scaffold.sh .`，即可应用所选
+> 技术栈、替换占位符，并自清理 `bin/`/`presets/`/`docs/superpowers/`。
+
+## 占位符替换
+
+| 令牌 | 值 |
+|---|---|
+| `{{PROJECT_NAME}}` | `--name` 的值，或目标目录名 |
+| `{{JAVA_VERSION}}` | `1.8`（springboot 预设默认值） |
+
+## 关键模式
+
+- **P0/P1/P2 优先级分级**：定义于 `common.md` + `AGENTS.md`。P0 = 安全/密钥/数据破坏，无一例外。
+- **SDLC 角色分离**：developer/tester/verifier 三个 agent + `/sdlc-cycle` 自动化命令。
+- **skill-evolve / agent-evolve**：从错误中提炼 "Learned warnings" 并追加的自我改进模式。`skill-evolve` 作用于 `.claude/skills/*.md`，`agent-evolve` 作用于 `.claude/agents/*.md`。
+- **Memory SSOT**：`.claude/memory/`（不使用系统默认路径）。类型前缀：`project_`/`feedback_`/`reference_`/`user_`。
+- **按路径作用域加载的规则**：frontmatter `paths:` 使规则仅在处理匹配文件时自动加载。
+- **多 agent 隔离**：并行 subagent 可能同时触碰同一文件时，使用 `isolation: "worktree"`。
+
+## 贡献
+
+工作流见 [CONTRIBUTING.md](CONTRIBUTING.md)，
+技术栈预设格式见 [docs/PRESET_SPEC.md](docs/PRESET_SPEC.md)。
+初来乍到？从 [`good first issue`](https://github.com/LeeYudok/claude-scaffold/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) 开始——
+新增一个技术栈预设是最容易上手的任务，因为其结构已完全模板化。
+
+## License
+
+MIT —— 见 [LICENSE](LICENSE)。


### PR DESCRIPTION
- Adds README.zh.md (简体中文) and README.ja.md (日本語), full translations of README.en.md, with a 4-language switcher across all READMEs.
- Gates the claude-review / claude-assistant workflows behind the repo variable `CLAUDE_REVIEW_ENABLED` so they no-op instead of failing on repos without the `ANTHROPIC_API_KEY` secret (this repo currently has none — set the secret and the variable to enable).

Made with [Orca](https://github.com/stablyai/orca) 🐋
