### PR TITLE
feat: flutter stack preset

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -142,6 +142,7 @@ tests/                    bats regression suite for the bootstrap script
 | `go` | go.md (paths: **/*.go) | `go build ./...` + `vet` + `golangci-lint` |
 | `rust` | rust.md (paths: src/**/*.rs, **/*.rs) | `cargo check` + `clippy` |
 | `android` | android.md (paths: **/*.kt) | `./gradlew ktlintCheck detekt` |
+| `flutter` | flutter.md (paths: **/*.dart, pubspec.yaml) | `dart format` + `flutter analyze` + `test` |
 | `ops` | ops.md (paths: Dockerfile, docker-compose*, quadlet/**, ansible/**) | — |
 
 ## Forge presets (`--forge`)

--- a/README.ja.md
+++ b/README.ja.md
@@ -142,6 +142,7 @@ tests/                    ブートストラップスクリプト用 bats リグ
 | `go` | go.md (paths: **/*.go) | `go build ./...` + `vet` + `golangci-lint` |
 | `rust` | rust.md (paths: src/**/*.rs, **/*.rs) | `cargo check` + `clippy` |
 | `android` | android.md (paths: **/*.kt) | `./gradlew ktlintCheck detekt` |
+| `flutter` | flutter.md (paths: **/*.dart, pubspec.yaml) | `dart format` + `flutter analyze` + `test` |
 | `ops` | ops.md (paths: Dockerfile, docker-compose*, quadlet/**, ansible/**) | — |
 
 ## Forge プリセット (`--forge`)

--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ bin/                    claude-scaffold.sh 부트스트랩 스크립트
 | `go` | go.md (paths: **/*.go) | `go build ./...` + `vet` + `golangci-lint` |
 | `rust` | rust.md (paths: src/**/*.rs, **/*.rs) | `cargo check` + `clippy` |
 | `android` | android.md (paths: **/*.kt) | `./gradlew ktlintCheck detekt` |
+| `flutter` | flutter.md (paths: **/*.dart, pubspec.yaml) | `dart format` + `flutter analyze` + `test` |
 | `ops` | ops.md (paths: Dockerfile, docker-compose*, quadlet/**, ansible/**) | — |
 
 ## Forge 프리셋 (`--forge`)

--- a/README.zh.md
+++ b/README.zh.md
@@ -140,6 +140,7 @@ tests/                    引导脚本的 bats 回归测试套件
 | `go` | go.md (paths: **/*.go) | `go build ./...` + `vet` + `golangci-lint` |
 | `rust` | rust.md (paths: src/**/*.rs, **/*.rs) | `cargo check` + `clippy` |
 | `android` | android.md (paths: **/*.kt) | `./gradlew ktlintCheck detekt` |
+| `flutter` | flutter.md (paths: **/*.dart, pubspec.yaml) | `dart format` + `flutter analyze` + `test` |
 | `ops` | ops.md (paths: Dockerfile, docker-compose*, quadlet/**, ansible/**) | — |
 
 ## Forge 预设（`--forge`）

--- a/bin/claude-scaffold.sh
+++ b/bin/claude-scaffold.sh
@@ -240,7 +240,7 @@ case "$LANG_OPT" in
 esac
 
 # 스택 미지정 + 대화형이면 묻는다
-AVAILABLE_STACKS="nextjs, springboot, javaweb, bun, python, go, rust, android, ops"
+AVAILABLE_STACKS="nextjs, springboot, javaweb, bun, python, go, rust, android, flutter, ops"
 if [ -z "$STACKS" ] && [ "$ASSUME_YES" -eq 0 ] && [ -t 0 ]; then
   echo "Select stack presets (comma-separated, blank=common only): $AVAILABLE_STACKS" >&2
   printf "stack> " >&2

--- a/presets/flutter/.claude/hooks/pre-commit.partial.sh
+++ b/presets/flutter/.claude/hooks/pre-commit.partial.sh
@@ -1,0 +1,20 @@
+# --- Flutter format + analyze + test gate ---
+if [ -f pubspec.yaml ] && command -v flutter >/dev/null 2>&1; then
+  echo "dart format check..." >&2
+  if ! dart format --set-exit-if-changed . >/dev/null 2>&1; then
+    echo "차단: dart format 미적용 파일이 있음. 'dart format .' 실행 후 커밋." >&2
+    exit 2
+  fi
+  echo "flutter analyze..." >&2
+  if ! flutter analyze 2>&1; then
+    echo "차단: flutter analyze 실패." >&2
+    exit 2
+  fi
+  if [ -d test ]; then
+    echo "flutter test..." >&2
+    if ! flutter test 2>&1; then
+      echo "차단: flutter test 실패." >&2
+      exit 2
+    fi
+  fi
+fi

--- a/presets/flutter/.claude/rules/flutter.md
+++ b/presets/flutter/.claude/rules/flutter.md
@@ -1,0 +1,36 @@
+---
+paths:
+  - "**/*.dart"
+  - "pubspec.yaml"
+  - "analysis_options.yaml"
+---
+
+# Flutter (Dart) 규칙
+
+## 빌드 & 테스트
+- **CI 순서 (빠른 실패 우선)**:
+  1. `dart format --set-exit-if-changed .` — 가장 빠름
+  2. `flutter analyze` — 정적 분석 (`analysis_options.yaml` 기준)
+  3. `flutter test` — 단위/위젯 테스트
+- 릴리즈 검증은 `flutter build apk --release` / `flutter build ios --release --no-codesign` 을 CI 별도 잡으로.
+
+## 의존성 관리
+- `pubspec.yaml` 버전은 caret(`^`) 제약 사용, `any` 금지. `pubspec.lock` 은 앱이면 커밋, 패키지면 미커밋.
+- 신규 의존성 추가 전 pub.dev 점수(likes/pub points)와 유지보수 상태 확인.
+- `flutter_lints` (또는 상위 호환 `very_good_analysis`) 를 `analysis_options.yaml` 에 포함 — 린트 규칙 임의 전면 해제 금지.
+
+## 코드 컨벤션
+- 위젯은 가능한 한 `const` 생성자 — `prefer_const_constructors` 린트 준수.
+- `build()` 안에서 비즈니스 로직·비동기 호출 금지 — 상태 관리 계층(Riverpod/Bloc 등 프로젝트 채택 라이브러리)으로 분리.
+- 상태 관리 라이브러리는 **하나만** 채택하고 혼용 금지.
+- `BuildContext` 를 `async` gap 너머로 사용 금지 (`use_build_context_synchronously`) — `mounted` 확인 후 사용.
+- 파일명 snake_case, 위젯 1개 = 파일 1개 원칙 (300줄 초과 시 분리 검토).
+
+## 테스트 패턴
+- 새 위젯에는 최소 1개 위젯 테스트(`testWidgets`) — 렌더링과 핵심 인터랙션 어설션.
+- 상태/서비스 로직은 순수 Dart 단위 테스트로 — 위젯 테스트에 로직 검증을 몰지 말 것.
+- 골든 테스트는 플랫폼별 렌더링 차이가 있으므로 CI 러너와 로컬 환경을 일치시킨 뒤에만 도입.
+
+## 금지
+- `print()` 디버깅 잔재 커밋 금지 — `debugPrint`/logger 사용, 릴리즈 코드에선 제거.
+- `// ignore:` 지시어는 사유 주석 + 이슈 번호 없이 금지.

--- a/presets/lang-en/stacks/flutter/.claude/rules/flutter.md
+++ b/presets/lang-en/stacks/flutter/.claude/rules/flutter.md
@@ -1,0 +1,36 @@
+---
+paths:
+  - "**/*.dart"
+  - "pubspec.yaml"
+  - "analysis_options.yaml"
+---
+
+# Flutter (Dart) Rules
+
+## Build & test
+- **CI order (fail fast)**:
+  1. `dart format --set-exit-if-changed .` — fastest
+  2. `flutter analyze` — static analysis (per `analysis_options.yaml`)
+  3. `flutter test` — unit/widget tests
+- Release verification (`flutter build apk --release` / `flutter build ios --release --no-codesign`) belongs in a separate CI job.
+
+## Dependency management
+- Use caret (`^`) constraints in `pubspec.yaml`, never `any`. Commit `pubspec.lock` for apps; don't for packages.
+- Before adding a dependency, check its pub.dev score (likes/pub points) and maintenance status.
+- Include `flutter_lints` (or the stricter `very_good_analysis`) in `analysis_options.yaml` — no blanket lint disabling.
+
+## Code conventions
+- Prefer `const` widget constructors — honor `prefer_const_constructors`.
+- No business logic or async calls inside `build()` — push them into the state-management layer (Riverpod/Bloc, whichever the project adopted).
+- Adopt **one** state-management library; do not mix.
+- Never use `BuildContext` across an `async` gap (`use_build_context_synchronously`) — check `mounted` first.
+- snake_case file names; one widget per file (consider splitting past 300 lines).
+
+## Test patterns
+- Every new widget gets at least one widget test (`testWidgets`) asserting rendering and the key interaction.
+- Test state/service logic as pure Dart unit tests — don't cram logic assertions into widget tests.
+- Introduce golden tests only after pinning CI runner and local environments — platform rendering differs.
+
+## Forbidden
+- No leftover `print()` debugging — use `debugPrint`/a logger, strip from release code.
+- No `// ignore:` directives without a reason comment and an issue number.


### PR DESCRIPTION
Closes #6

Adds the `flutter` stack preset:

- `presets/flutter/.claude/rules/flutter.md` — build/test order (format → analyze → test), pubspec constraint rules, const widgets, no logic in `build()`, `BuildContext` async-gap ban, widget/unit test patterns
- `presets/flutter/.claude/hooks/pre-commit.partial.sh` — `dart format --set-exit-if-changed` + `flutter analyze` + `flutter test` (when `test/` exists); no-ops when `pubspec.yaml` or the flutter CLI is absent; no `exit 0` per the partial contract
- English mirror at `presets/lang-en/stacks/flutter/`
- Stack table row in all four READMEs, `AVAILABLE_STACKS` updated

Verified: scratch bootstrap with `--stack flutter,go` splices both gates; `--lang en` loads the English rules; bats 31 + unittest 22 green.

Made with [Orca](https://github.com/stablyai/orca) 🐋
