### PR TITLE
docs: credit third-party open-source origins

### DIFF
--- a/.claude/skills/grill-me/SKILL.md
+++ b/.claude/skills/grill-me/SKILL.md
@@ -6,6 +6,9 @@ user-invocable: true
 
 # Grill Me — 적대적 요구사항 심문
 
+> [obra/superpowers](https://github.com/obra/superpowers)(MIT) 의 `brainstorming` 스킬에서
+> 영감을 받아 그 opt-in 대체재로 설계한 자체 스킬 — 이후 워크플로(계획 → TDD → 리뷰)는 superpowers 의 프로세스를 따른다.
+
 스펙이 더 이상 바뀌지 않을 때까지 사용자의 아이디어를 심문한 뒤, 단단해진 스펙을
 일반 구현 플로에 넘긴다. 이 스킬을 명시적으로 호출하면 현재 작업에 한해
 `superpowers:brainstorming` 을 대체하며, 이후 단계(계획 → TDD → 리뷰)는 그대로다.

--- a/.claude/skills/search-first/SKILL.md
+++ b/.claude/skills/search-first/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: search-first
-description: 코드를 새로 짜기 전에 기존 솔루션(레포 내부 → 사내 미러 → 패키지 레지스트리 → MCP/스킬 → GitHub)을 먼저 검색하는 워크플로. 새 기능/유틸/의존성 추가 직전, "X 기능 넣어줘" 요청에 코드부터 쓰려는 순간 발동. (원본: ECC search-first, mirrors/ECC)
+description: 코드를 새로 짜기 전에 기존 솔루션(레포 내부 → 사내 미러 → 패키지 레지스트리 → MCP/스킬 → GitHub)을 먼저 검색하는 워크플로. 새 기능/유틸/의존성 추가 직전, "X 기능 넣어줘" 요청에 코드부터 쓰려는 순간 발동. (원본: [affaan-m/ECC](https://github.com/affaan-m/ECC) 의 search-first 스킬, MIT — 이식·번안)
 allowed-tools: Bash, Read, Grep, Glob, WebSearch, WebFetch
 ---
 

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -1,0 +1,13 @@
+# Credits — third-party origins
+
+claude-scaffold bundles or adapts work from the following open-source projects.
+Thank you to their authors.
+
+| What in this repo | Upstream | License |
+|---|---|---|
+| `.claude/skills/search-first/` (and its English mirror) — ported and adapted from the upstream skill of the same name | [affaan-m/ECC](https://github.com/affaan-m/ECC) | MIT |
+| `docs/ECC_MANIFESTS.md` — an analysis of the upstream `manifests/` install architecture | [affaan-m/ECC](https://github.com/affaan-m/ECC) | MIT |
+| `.claude/skills/grill-me/` — an original skill designed as an opt-in alternative to the upstream `brainstorming` skill; the surrounding workflow (plan → TDD → review) follows the upstream's process, and `docs/superpowers/specs/` uses its spec-writing format | [obra/superpowers](https://github.com/obra/superpowers) | MIT |
+| `.claude/skills/skill-evolve/`, `.claude/skills/memory-factcheck/` — deliberate template-bundling forks of the skills of the same names (same author as this repo) | [leeyudok/doksam-skills](https://github.com/leeyudok/doksam-skills) | MIT |
+
+If you notice a missing attribution, please open an issue.

--- a/README.en.md
+++ b/README.en.md
@@ -264,4 +264,4 @@ adding a new stack preset is the most approachable one, since the layout is full
 
 ## License
 
-MIT — see [LICENSE](LICENSE).
+MIT — see [LICENSE](LICENSE). Third-party origins (skills/docs) are listed in [CREDITS.md](CREDITS.md).

--- a/README.ja.md
+++ b/README.ja.md
@@ -263,4 +263,4 @@ claude-scaffold/bin/claude-scaffold.sh --update /path/to/existing-repo
 
 ## ライセンス
 
-MIT — [LICENSE](LICENSE) を参照してください。
+MIT — [LICENSE](LICENSE) を参照してください。サードパーティ由来（スキル・ドキュメント）は [CREDITS.md](CREDITS.md) に記載しています。

--- a/README.md
+++ b/README.md
@@ -245,4 +245,4 @@ claude-scaffold/bin/claude-scaffold.sh --update /path/to/existing-repo
 
 ## License
 
-MIT — see [LICENSE](LICENSE).
+MIT — see [LICENSE](LICENSE). 서드파티 유래(스킬·문서)는 [CREDITS.md](CREDITS.md) 참조.

--- a/README.zh.md
+++ b/README.zh.md
@@ -261,4 +261,4 @@ claude-scaffold/bin/claude-scaffold.sh --update /path/to/existing-repo
 
 ## License
 
-MIT —— 见 [LICENSE](LICENSE)。
+MIT —— 见 [LICENSE](LICENSE)。第三方来源（技能/文档）见 [CREDITS.md](CREDITS.md)。

--- a/docs/ECC_MANIFESTS.md
+++ b/docs/ECC_MANIFESTS.md
@@ -1,6 +1,6 @@
 # ECC manifests 구조 분석 — 프리셋 확장 시 참고
 
-> 출처: ECC(everything-claude-code) `manifests/` (2026-07-09 스냅샷, 사내 미러 경유).
+> 출처: ECC([affaan-m/ECC](https://github.com/affaan-m/ECC), MIT) `manifests/` (2026-07-09 스냅샷).
 > claude-scaffold 프리셋(현 10종 스택 + forge 2종)이 더 늘어나 "스택 = 프리셋 1개" 평면 구조가
 > 버거워질 때 참고할 선택 설치 설계. **지금 당장 도입하는 것 아님** — 임계점은 아래 "도입 판단" 참조.
 

--- a/presets/lang-en/base/.claude/skills/grill-me/SKILL.md
+++ b/presets/lang-en/base/.claude/skills/grill-me/SKILL.md
@@ -6,6 +6,10 @@ user-invocable: true
 
 # Grill Me — adversarial requirements interrogation
 
+> An original skill inspired by — and designed as an opt-in alternative to — the
+> `brainstorming` skill from [obra/superpowers](https://github.com/obra/superpowers) (MIT);
+> the downstream workflow (plan → TDD → review) follows the superpowers process.
+
 Interrogate the user's idea until the spec stops changing, then hand a hardened spec
 to the normal implementation flow. Explicitly invoking this skill substitutes for
 `superpowers:brainstorming` for the current task; everything downstream

--- a/presets/lang-en/base/.claude/skills/search-first/SKILL.md
+++ b/presets/lang-en/base/.claude/skills/search-first/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: search-first
-description: A workflow that searches for an existing solution (this repo → internal mirrors → package registries → MCP/skills → GitHub) before writing new code. Triggers right before adding a new feature/utility/dependency, or the moment a "add feature X" request tempts you to jump straight to code. (Origin: ECC search-first, mirrors/ECC)
+description: A workflow that searches for an existing solution (this repo → internal mirrors → package registries → MCP/skills → GitHub) before writing new code. Triggers right before adding a new feature/utility/dependency, or the moment a "add feature X" request tempts you to jump straight to code. (Origin: the search-first skill from [affaan-m/ECC](https://github.com/affaan-m/ECC), MIT — ported and adapted)
 allowed-tools: Bash, Read, Grep, Glob, WebSearch, WebFetch
 ---
 


### PR DESCRIPTION
Adds CREDITS.md and per-file attribution for everything in this repo that originates from other open-source projects:

- **affaan-m/ECC** (MIT) — the `search-first` skill (ported/adapted) and `docs/ECC_MANIFESTS.md` (analysis of its manifests architecture)
- **obra/superpowers** (MIT) — `grill-me` is an original opt-in alternative inspired by its `brainstorming` skill; `docs/superpowers/specs/` uses its spec format
- **leeyudok/doksam-skills** (MIT, same author) — `skill-evolve` / `memory-factcheck` forks (already noted in-file)

All four README language variants now point at CREDITS.md from the License section.