### PR TITLE
chore(#16): rename claude-scaffold -> agents-scaffold repo-wide

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -14,7 +14,7 @@ assignees: ''
 
 ```bash
 # the exact command(s) you ran, e.g.
-# bin/claude-scaffold.sh my-app --stack nextjs --yes
+# bin/agents-scaffold.sh my-app --stack nextjs --yes
 ```
 
 ## Environment

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@ Closes #<!-- issue number -->
 
 ## Checklist
 
-- [ ] `bats tests/claude-scaffold.bats` passes locally
+- [ ] `bats tests/agents-scaffold.bats` passes locally
 - [ ] `python3 -m unittest discover -s tests` passes locally
 - [ ] Korean originals and `presets/lang-en/` mirror are both updated (if docs/rules changed)
 - [ ] README stack table updated (if a preset was added/changed)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,5 +17,5 @@ jobs:
       - name: Run python unit tests
         run: python3 -m unittest discover -s tests -p 'test_*.py' -v
 
-      - name: Run claude-scaffold.sh bats tests
-        run: bats tests/claude-scaffold.bats
+      - name: Run agents-scaffold.sh bats tests
+        run: bats tests/agents-scaffold.bats

--- a/.reviewbot.yml
+++ b/.reviewbot.yml
@@ -1,7 +1,7 @@
-# 전역 리뷰봇(srope/review-bot) — claude-scaffold 고유 리뷰 관점
+# 전역 리뷰봇(srope/review-bot) — agents-scaffold 고유 리뷰 관점
 extra_rules:
-  - "bin/claude-scaffold.sh 는 TARGET 경로 기준으로 rm -rf 를 실행한다(예: `rm -rf \"$TARGET/bin\" \"$TARGET/presets\" ...`) — TARGET 산출 로직이나 경로 검증을 건드리는 변경은 빈 변수·상위 디렉터리 이탈로 의도치 않은 삭제가 없는지 확인"
-  - "README Quickstart 가 `curl | bash` 원격 스크립트 실행을 안내한다 — bin/claude-scaffold.sh 및 다운로드 대상 URL 변경 시 무결성 검증 없이 임의 코드 실행으로 이어지지 않는지 확인"
+  - "bin/agents-scaffold.sh 는 TARGET 경로 기준으로 rm -rf 를 실행한다(예: `rm -rf \"$TARGET/bin\" \"$TARGET/presets\" ...`) — TARGET 산출 로직이나 경로 검증을 건드리는 변경은 빈 변수·상위 디렉터리 이탈로 의도치 않은 삭제가 없는지 확인"
+  - "README Quickstart 가 `curl | bash` 원격 스크립트 실행을 안내한다 — bin/agents-scaffold.sh 및 다운로드 대상 URL 변경 시 무결성 검증 없이 임의 코드 실행으로 이어지지 않는지 확인"
   - ".claude/settings.json 의 deny 규칙·훅 바인딩(P0 강제 게이트) 자체가 이 레포의 산출물이므로, presets/*.partial.sh 나 settings 조각 수정이 다른 프로젝트로 배포됐을 때 P0 게이트(시크릿 노출 차단, 인증 누락 방지 등)를 약화시키지 않는지 확인"
   - "AGENTS.md/CLAUDE.md/presets 는 `{{PROJECT_NAME}}` 등 플레이스홀더를 포함한 fork-and-fill 템플릿이다 — 신규 프리셋/문서 추가 시 플레이스홀더 치환 누락이나 실제 값 오기입 여부 확인"
 context_files: [AGENTS.md, CLAUDE.md]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,12 +1,12 @@
-# Contributing to claude-scaffold
+# Contributing to agents-scaffold
 
-Thanks for considering a contribution! claude-scaffold is a minimal `.claude/`
+Thanks for considering a contribution! agents-scaffold is a minimal `.claude/`
 bootstrap template, not a running application — most contributions are Markdown
 (rules, agent/skill definitions) and small shell scripts (hooks,
-`bin/claude-scaffold.sh`, `presets/*/.claude/hooks/pre-commit.partial.sh`).
+`bin/agents-scaffold.sh`, `presets/*/.claude/hooks/pre-commit.partial.sh`).
 The easiest way to make a first contribution is a **new stack preset** — see
 the section below and the issues labeled
-[`good first issue`](https://github.com/LeeYudok/claude-scaffold/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22).
+[`good first issue`](https://github.com/LeeYudok/agents-scaffold/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22).
 
 ## Workflow (GitHub)
 
@@ -21,7 +21,7 @@ the section below and the issues labeled
 
    ```bash
    # bats (bootstrap script + presets); install: https://bats-core.readthedocs.io
-   bats tests/claude-scaffold.bats
+   bats tests/agents-scaffold.bats
 
    # python unit tests (hook/link-checker helpers)
    python3 -m unittest discover -s tests
@@ -30,7 +30,7 @@ the section below and the issues labeled
    The same suite runs in CI on every PR — a green run is required to merge.
 5. **Pull request** against `main` with `Closes #<N>` in the description.
    Merging auto-closes the issue.
-6. **Review.** Changes to `bin/claude-scaffold.sh`, `.claude/hooks/pre-commit.sh`,
+6. **Review.** Changes to `bin/agents-scaffold.sh`, `.claude/hooks/pre-commit.sh`,
    or any `pre-commit.partial.sh` get extra scrutiny — these are load-bearing
    for every repo that bootstraps from this template.
 
@@ -41,13 +41,13 @@ the section below and the issues labeled
   `GEMINI.md`): applies to every consuming repo regardless of stack. Changes
   here have the widest blast radius — keep them stack-agnostic.
 - **Stack presets** (`presets/<stack>/`): opt-in, applied only when a repo
-  selects that stack via `bin/claude-scaffold.sh --stack <name>`. See
+  selects that stack via `bin/agents-scaffold.sh --stack <name>`. See
   [docs/PRESET_SPEC.md](docs/PRESET_SPEC.md) for the required layout.
 - **English overlay** (`presets/lang-en/`): the English mirror of the Korean
   originals. If you change a Korean rule/agent/skill, mirror the change in
   `presets/lang-en/` in the same PR (and vice versa). Executable scripts are
   written in English once and shared — do not duplicate them into the overlay.
-- **Bootstrap script** (`bin/claude-scaffold.sh`): the only piece of logic that
+- **Bootstrap script** (`bin/agents-scaffold.sh`): the only piece of logic that
   copies files, applies presets, and substitutes placeholders. Changes here
   affect every mode of consumption — test them with the bats suite.
 
@@ -65,7 +65,7 @@ the section below and the issues labeled
 3. Add the English rule file at `presets/lang-en/stacks/<stack>/.claude/rules/<stack>.md`.
 4. Add a row to the stack preset table in `README.md` and `README.en.md`
    (rule file + pre-commit gate description).
-5. Bootstrap a scratch repo with `bin/claude-scaffold.sh /tmp/scratch --stack
+5. Bootstrap a scratch repo with `bin/agents-scaffold.sh /tmp/scratch --stack
    <your-stack> --name scratch` and confirm:
    - the rule file lands at `.claude/rules/<stack>.md` with correct
      frontmatter `paths:`,

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -1,6 +1,6 @@
 # Credits — third-party origins
 
-claude-scaffold bundles or adapts work from the following open-source projects.
+agents-scaffold bundles or adapts work from the following open-source projects.
 Thank you to their authors.
 
 | What in this repo | Upstream | License |

--- a/README.en.md
+++ b/README.en.md
@@ -1,8 +1,8 @@
-# claude-scaffold
+# agents-scaffold
 
 [한국어](README.md) | English | [简体中文](README.zh.md) | [日本語](README.ja.md)
 
-[![tests](https://github.com/leeyudok/claude-scaffold/actions/workflows/test.yml/badge.svg)](https://github.com/leeyudok/claude-scaffold/actions/workflows/test.yml)
+[![tests](https://github.com/leeyudok/agents-scaffold/actions/workflows/test.yml/badge.svg)](https://github.com/leeyudok/agents-scaffold/actions/workflows/test.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
 **Not a framework — a minimal, fork-and-fill bootstrap for Claude Code** with
@@ -17,11 +17,11 @@ _30-second demo: one command → a filled `.claude/` → the gate blocks a secre
 
 ```bash
 # one command, no clone required
-curl -fsSL https://raw.githubusercontent.com/leeyudok/claude-scaffold/main/bin/claude-scaffold.sh | bash -s -- --stack nextjs --yes
+curl -fsSL https://raw.githubusercontent.com/leeyudok/agents-scaffold/main/bin/agents-scaffold.sh | bash -s -- --stack nextjs --yes
 
 # or from a local clone (prompts interactively when options are omitted)
-git clone https://github.com/leeyudok/claude-scaffold.git
-claude-scaffold/bin/claude-scaffold.sh /path/to/new-repo --forge github --stack nextjs,bun --name my-app
+git clone https://github.com/leeyudok/agents-scaffold.git
+agents-scaffold/bin/agents-scaffold.sh /path/to/new-repo --forge github --stack nextjs,bun --name my-app
 ```
 
 You get a filled-in `.claude/` directory (agents, skills, hooks, paths-scoped
@@ -59,9 +59,9 @@ you're new to prompting:
 - **Team/multi-session safe**: per-session git worktree isolation is the default, so
   parallel work never tramples each other.
 
-## Why claude-scaffold
+## Why agents-scaffold
 
-Unlike large installable frameworks or agent/skill catalogs, claude-scaffold ships
+Unlike large installable frameworks or agent/skill catalogs, agents-scaffold ships
 no runtime, no plugin system, and no central registry to keep in sync — it is
 a `.claude/` directory skeleton plus a handful of stack presets that you copy
 into a repo once and then own outright. There is nothing to upgrade later:
@@ -126,7 +126,7 @@ presets/                  preset fragments (copy-overwrite model)
   forge-gitlab/           GitLab forge — glab, MRs, `Closes #N` auto-close (verify after merge)
   nextjs/ bun/ ...        per-stack fragments (rules + pre-commit.partial.sh)
   lang-en/                English overlay (base/forge-*/stacks/*) — see `--lang` below
-bin/                      claude-scaffold.sh bootstrap script
+bin/                      agents-scaffold.sh bootstrap script
 tests/                    bats regression suite for the bootstrap script
 ```
 
@@ -168,7 +168,7 @@ stack presets — so it overrides the same files with `presets/lang-en/base` +
 `presets/lang-en/forge-<forge>` + `presets/lang-en/stacks/<stack>` content.
 
 ```bash
-claude-scaffold/bin/claude-scaffold.sh /path/to/new-repo --lang en --forge github --stack bun
+agents-scaffold/bin/agents-scaffold.sh /path/to/new-repo --lang en --forge github --stack bun
 ```
 
 `.claude/hooks/pre-commit.sh` is never overlaid by `--lang` (it's the file
@@ -179,9 +179,9 @@ by language). `--update` only refreshes the Korean base; re-run with
 ## Usage 1 — script
 
 ```bash
-git clone https://github.com/leeyudok/claude-scaffold.git
+git clone https://github.com/leeyudok/agents-scaffold.git
 # --forge defaults to github; use --forge gitlab for GitLab repos
-claude-scaffold/bin/claude-scaffold.sh /path/to/new-repo --forge github --stack nextjs,bun --name my-app
+agents-scaffold/bin/agents-scaffold.sh /path/to/new-repo --forge github --stack nextjs,bun --name my-app
 ```
 
 Omit `--forge`/`--stack`/`--name` to run interactively — the script will prompt
@@ -202,13 +202,13 @@ Omit `--forge`/`--stack`/`--name` to run interactively — the script will promp
 ### Remote one-command install (no clone)
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/leeyudok/claude-scaffold/main/bin/claude-scaffold.sh | bash -s -- --stack nextjs --yes
+curl -fsSL https://raw.githubusercontent.com/leeyudok/agents-scaffold/main/bin/agents-scaffold.sh | bash -s -- --stack nextjs --yes
 ```
 
 When the script detects it is not running from a local checkout (e.g. piped
-execution), it downloads the `CLAUDE_SCAFFOLD_REPO` tarball (default:
-`github.com/leeyudok/claude-scaffold`, override via env) into a temporary directory and
-uses it as the template source. Pin a branch/tag with `CLAUDE_SCAFFOLD_REF`
+execution), it downloads the `AGENTS_SCAFFOLD_REPO` tarball (default:
+`github.com/leeyudok/agents-scaffold`, override via env) into a temporary directory and
+uses it as the template source. Pin a branch/tag with `AGENTS_SCAFFOLD_REF`
 (default `main`).
 
 ### Updating the base — `--update`
@@ -217,7 +217,7 @@ Applies the latest base files (`.claude/`, `AGENTS.md`, `CLAUDE.md`,
 `GEMINI.md`) to an already-bootstrapped project.
 
 ```bash
-claude-scaffold/bin/claude-scaffold.sh --update /path/to/existing-repo
+agents-scaffold/bin/agents-scaffold.sh --update /path/to/existing-repo
 ```
 
 - `.claude/hooks/pre-commit.sh` is always skipped — stack partials were spliced
@@ -235,8 +235,8 @@ see **[docs/GITLAB_TEMPLATE.md](docs/GITLAB_TEMPLATE.md)**.
 
 > Note: this workflow assumes a self-hosted GitLab instance. On **GitLab CE**,
 > native custom project templates are a Premium feature and unavailable —
-> use **Import by URL + `bin/claude-scaffold.sh`** or **the script alone** instead.
-> After creating/importing, run `bin/claude-scaffold.sh .` once to apply the
+> use **Import by URL + `bin/agents-scaffold.sh`** or **the script alone** instead.
+> After creating/importing, run `bin/agents-scaffold.sh .` once to apply the
 > chosen stacks, substitute placeholders, and self-clean `bin/`/`presets/`/`docs/superpowers/`.
 
 ## Placeholder substitution
@@ -259,7 +259,7 @@ see **[docs/GITLAB_TEMPLATE.md](docs/GITLAB_TEMPLATE.md)**.
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for the workflow and
 [docs/PRESET_SPEC.md](docs/PRESET_SPEC.md) for the stack preset format.
-New here? Start with a [`good first issue`](https://github.com/LeeYudok/claude-scaffold/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) —
+New here? Start with a [`good first issue`](https://github.com/LeeYudok/agents-scaffold/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) —
 adding a new stack preset is the most approachable one, since the layout is fully templated.
 
 ## License

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,8 +1,8 @@
-# claude-scaffold
+# agents-scaffold
 
 [한국어](README.md) | [English](README.en.md) | [简体中文](README.zh.md) | 日本語
 
-[![tests](https://github.com/leeyudok/claude-scaffold/actions/workflows/test.yml/badge.svg)](https://github.com/leeyudok/claude-scaffold/actions/workflows/test.yml)
+[![tests](https://github.com/leeyudok/agents-scaffold/actions/workflows/test.yml/badge.svg)](https://github.com/leeyudok/agents-scaffold/actions/workflows/test.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
 **フレームワークではありません — Claude Code のためのミニマルな fork-and-fill ブートストラップです**。
@@ -17,11 +17,11 @@ _30秒デモ: コマンド1つ → 記入済みの `.claude/` → ゲートが�
 
 ```bash
 # クローン不要、コマンド1つで
-curl -fsSL https://raw.githubusercontent.com/leeyudok/claude-scaffold/main/bin/claude-scaffold.sh | bash -s -- --stack nextjs --yes
+curl -fsSL https://raw.githubusercontent.com/leeyudok/agents-scaffold/main/bin/agents-scaffold.sh | bash -s -- --stack nextjs --yes
 
 # またはローカルクローンから(オプション省略時は対話的にプロンプト)
-git clone https://github.com/leeyudok/claude-scaffold.git
-claude-scaffold/bin/claude-scaffold.sh /path/to/new-repo --forge github --stack nextjs,bun --name my-app
+git clone https://github.com/leeyudok/agents-scaffold.git
+agents-scaffold/bin/agents-scaffold.sh /path/to/new-repo --forge github --stack nextjs,bun --name my-app
 ```
 
 記入済みの `.claude/` ディレクトリ(エージェント、スキル、フック、paths スコープの
@@ -59,9 +59,9 @@ claude-scaffold/bin/claude-scaffold.sh /path/to/new-repo --forge github --stack 
 - **チーム/マルチセッションでも安全**: セッションごとの git worktree 分離が
   デフォルトなので、並行作業が互いを踏み荒らすことはありません。
 
-## なぜ claude-scaffold か
+## なぜ agents-scaffold か
 
-大規模なインストール型フレームワークやエージェント/スキルのカタログと違い、claude-scaffold は
+大規模なインストール型フレームワークやエージェント/スキルのカタログと違い、agents-scaffold は
 ランタイムも、プラグインシステムも、同期を保つべき中央レジストリも持ちません —
 これは `.claude/` ディレクトリのスケルトンと少数のスタックプリセットであり、
 一度リポジトリにコピーしたらあとは完全にあなたのものです。後からアップグレードすべきものは
@@ -126,7 +126,7 @@ presets/                  プリセット断片(コピー上書きモデル)
   forge-gitlab/           GitLab forge — glab、MR、`Closes #N` 自動クローズ(マージ後に確認)
   nextjs/ bun/ ...        スタック別断片(rules + pre-commit.partial.sh)
   lang-en/                英語オーバーレイ(base/forge-*/stacks/*)— 後述の `--lang` を参照
-bin/                      claude-scaffold.sh ブートストラップスクリプト
+bin/                      agents-scaffold.sh ブートストラップスクリプト
 tests/                    ブートストラップスクリプト用 bats リグレッションスイート
 ```
 
@@ -168,7 +168,7 @@ forge プリセット、スタックプリセットの後に適用されるた�
 の内容で上書きします。
 
 ```bash
-claude-scaffold/bin/claude-scaffold.sh /path/to/new-repo --lang en --forge github --stack bun
+agents-scaffold/bin/agents-scaffold.sh /path/to/new-repo --lang en --forge github --stack bun
 ```
 
 `.claude/hooks/pre-commit.sh` は `--lang` によるオーバーレイの対象外です
@@ -179,9 +179,9 @@ claude-scaffold/bin/claude-scaffold.sh /path/to/new-repo --lang en --forge githu
 ## Usage 1 — script
 
 ```bash
-git clone https://github.com/leeyudok/claude-scaffold.git
+git clone https://github.com/leeyudok/agents-scaffold.git
 # --forge のデフォルトは github。GitLab リポジトリには --forge gitlab を使う
-claude-scaffold/bin/claude-scaffold.sh /path/to/new-repo --forge github --stack nextjs,bun --name my-app
+agents-scaffold/bin/agents-scaffold.sh /path/to/new-repo --forge github --stack nextjs,bun --name my-app
 ```
 
 `--forge`/`--stack`/`--name` を省略すると対話モードで実行され、スクリプトが
@@ -202,13 +202,13 @@ claude-scaffold/bin/claude-scaffold.sh /path/to/new-repo --forge github --stack 
 ### リモートワンコマンドインストール(クローン不要)
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/leeyudok/claude-scaffold/main/bin/claude-scaffold.sh | bash -s -- --stack nextjs --yes
+curl -fsSL https://raw.githubusercontent.com/leeyudok/agents-scaffold/main/bin/agents-scaffold.sh | bash -s -- --stack nextjs --yes
 ```
 
 スクリプトはローカルチェックアウトから実行されていないこと(パイプ実行など)を検知すると、
-`CLAUDE_SCAFFOLD_REPO` の tarball(デフォルト: `github.com/leeyudok/claude-scaffold`、
+`AGENTS_SCAFFOLD_REPO` の tarball(デフォルト: `github.com/leeyudok/agents-scaffold`、
 環境変数で上書き可)を一時ディレクトリにダウンロードし、テンプレートソースとして
-使用します。ブランチ/タグの固定は `CLAUDE_SCAFFOLD_REF`(デフォルト `main`)で行います。
+使用します。ブランチ/タグの固定は `AGENTS_SCAFFOLD_REF`(デフォルト `main`)で行います。
 
 ### ベースの更新 — `--update`
 
@@ -216,7 +216,7 @@ curl -fsSL https://raw.githubusercontent.com/leeyudok/claude-scaffold/main/bin/c
 `CLAUDE.md`、`GEMINI.md`)を適用します。
 
 ```bash
-claude-scaffold/bin/claude-scaffold.sh --update /path/to/existing-repo
+agents-scaffold/bin/agents-scaffold.sh --update /path/to/existing-repo
 ```
 
 - `.claude/hooks/pre-commit.sh` は常にスキップされます — スタックパーシャルが
@@ -234,8 +234,8 @@ claude-scaffold/bin/claude-scaffold.sh --update /path/to/existing-repo
 
 > 注: このワークフローはセルフホストの GitLab インスタンスを前提とします。**GitLab CE** では
 > ネイティブのカスタムプロジェクトテンプレートは Premium 機能のため利用できません —
-> 代わりに **Import by URL + `bin/claude-scaffold.sh`**、または**スクリプト単体**を使ってください。
-> 作成/インポート後に `bin/claude-scaffold.sh .` を1回実行すると、選択したスタックの適用、
+> 代わりに **Import by URL + `bin/agents-scaffold.sh`**、または**スクリプト単体**を使ってください。
+> 作成/インポート後に `bin/agents-scaffold.sh .` を1回実行すると、選択したスタックの適用、
 > プレースホルダー置換、`bin/`/`presets/`/`docs/superpowers/` のセルフクリーンが行われます。
 
 ## プレースホルダー置換
@@ -258,7 +258,7 @@ claude-scaffold/bin/claude-scaffold.sh --update /path/to/existing-repo
 
 ワークフローは [CONTRIBUTING.md](CONTRIBUTING.md)、スタックプリセットの形式は
 [docs/PRESET_SPEC.md](docs/PRESET_SPEC.md) を参照してください。
-初めての方は [`good first issue`](https://github.com/LeeYudok/claude-scaffold/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) から始めるのがおすすめです —
+初めての方は [`good first issue`](https://github.com/LeeYudok/agents-scaffold/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) から始めるのがおすすめです —
 レイアウトが完全にテンプレート化されているため、新しいスタックプリセットの追加が最も取り組みやすい課題です。
 
 ## ライセンス

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# claude-scaffold
+# agents-scaffold
 
 한국어 | [English](README.en.md) | [简体中文](README.zh.md) | [日本語](README.ja.md)
 
-[![tests](https://github.com/leeyudok/claude-scaffold/actions/workflows/test.yml/badge.svg)](https://github.com/leeyudok/claude-scaffold/actions/workflows/test.yml)
+[![tests](https://github.com/leeyudok/agents-scaffold/actions/workflows/test.yml/badge.svg)](https://github.com/leeyudok/agents-scaffold/actions/workflows/test.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
 **프레임워크가 아니라 fork-and-fill 미니멀 부트스트랩** — Claude Code 용 `.claude/` 초기
@@ -17,11 +17,11 @@ _30초 데모: 명령 한 번 → `.claude/` 완성 → 시크릿 커밋은 게�
 
 ```bash
 # clone 없이 원커맨드
-curl -fsSL https://raw.githubusercontent.com/leeyudok/claude-scaffold/main/bin/claude-scaffold.sh | bash -s -- --stack nextjs --yes
+curl -fsSL https://raw.githubusercontent.com/leeyudok/agents-scaffold/main/bin/agents-scaffold.sh | bash -s -- --stack nextjs --yes
 
 # 또는 로컬 clone 에서 (옵션 생략 시 대화형 프롬프트)
-git clone https://github.com/leeyudok/claude-scaffold.git
-claude-scaffold/bin/claude-scaffold.sh /path/to/new-repo --forge github --stack nextjs,bun --name my-app
+git clone https://github.com/leeyudok/agents-scaffold.git
+agents-scaffold/bin/agents-scaffold.sh /path/to/new-repo --forge github --stack nextjs,bun --name my-app
 ```
 
 결과물은 채워진 `.claude/` 디렉터리(agents·skills·hooks·paths 스코프 rules·memory),
@@ -57,9 +57,9 @@ claude-scaffold/bin/claude-scaffold.sh /path/to/new-repo --forge github --stack 
 - **팀/멀티세션 안전**: 세션마다 git worktree 격리 규칙이 기본이라 병렬 작업이 서로를
   덮어쓰지 않는다.
 
-## 왜 claude-scaffold 인가
+## 왜 agents-scaffold 인가
 
-대형 설치형 프레임워크나 에이전트/스킬 카탈로그와 달리, claude-scaffold 은 런타임도 플러그인
+대형 설치형 프레임워크나 에이전트/스킬 카탈로그와 달리, agents-scaffold 은 런타임도 플러그인
 시스템도 동기화할 중앙 레지스트리도 없다 — `.claude/` 디렉터리 골격 + 스택 프리셋 몇 개를
 레포에 한 번 복사하면 그걸로 끝이고, 이후 업그레이드할 대상 자체가 없다. fork 해서
 placeholder 를 채우고 안 쓰는 걸 지우면, 결과는 레포의 다른 코드와 똑같이 버전 관리되는
@@ -122,7 +122,7 @@ presets/                프리셋 조각 (복사 덮어쓰기 방식)
   forge-gitlab/         GitLab forge — glab, MR, `Closes #N` 자동 클로즈(머지 후 확인)
   nextjs/ bun/ ...      스택별 조각 (rules + pre-commit.partial.sh)
   lang-en/              영어 오버레이 (base/forge-*/stacks/*) — 아래 `--lang` 참조
-bin/                    claude-scaffold.sh 부트스트랩 스크립트
+bin/                    agents-scaffold.sh 부트스트랩 스크립트
 ```
 
 ## 스택 프리셋
@@ -160,7 +160,7 @@ bin/                    claude-scaffold.sh 부트스트랩 스크립트
 콘텐츠로 동일 파일을 덮어쓴다.
 
 ```bash
-claude-scaffold/bin/claude-scaffold.sh /path/to/new-repo --lang en --forge github --stack bun
+agents-scaffold/bin/agents-scaffold.sh /path/to/new-repo --lang en --forge github --stack bun
 ```
 
 `.claude/hooks/pre-commit.sh` 는 `--lang` 오버레이 대상이 아니다(스택 파셜이 삽입되는
@@ -170,9 +170,9 @@ claude-scaffold/bin/claude-scaffold.sh /path/to/new-repo --lang en --forge githu
 ## 사용법 1 — 스크립트
 
 ```bash
-git clone https://github.com/leeyudok/claude-scaffold.git
+git clone https://github.com/leeyudok/agents-scaffold.git
 # --forge 기본값 github. GitLab 레포면 --forge gitlab
-claude-scaffold/bin/claude-scaffold.sh /path/to/new-repo --forge github --stack nextjs,bun --name my-app
+agents-scaffold/bin/agents-scaffold.sh /path/to/new-repo --forge github --stack nextjs,bun --name my-app
 ```
 
 대화형으로 쓰려면 `--forge`/`--stack`/`--name` 생략 → 프롬프트가 묻는다(forge 기본 github).
@@ -192,12 +192,12 @@ claude-scaffold/bin/claude-scaffold.sh /path/to/new-repo --forge github --stack 
 ### 원격 원커맨드 설치 (clone 불필요)
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/leeyudok/claude-scaffold/main/bin/claude-scaffold.sh | bash -s -- --stack nextjs --yes
+curl -fsSL https://raw.githubusercontent.com/leeyudok/agents-scaffold/main/bin/agents-scaffold.sh | bash -s -- --stack nextjs --yes
 ```
 
-로컬에 레포가 없는 상태(파이프 실행)로 감지되면 `CLAUDE_SCAFFOLD_REPO`(기본
-`github.com/leeyudok/claude-scaffold`, env 로 오버라이드) tarball 을 임시 디렉터리에 받아 템플릿 소스로 쓴다. 브랜치/태그 지정은
-`CLAUDE_SCAFFOLD_REF`(기본 `main`) 로 오버라이드.
+로컬에 레포가 없는 상태(파이프 실행)로 감지되면 `AGENTS_SCAFFOLD_REPO`(기본
+`github.com/leeyudok/agents-scaffold`, env 로 오버라이드) tarball 을 임시 디렉터리에 받아 템플릿 소스로 쓴다. 브랜치/태그 지정은
+`AGENTS_SCAFFOLD_REF`(기본 `main`) 로 오버라이드.
 
 ### 베이스 갱신 — `--update`
 
@@ -205,7 +205,7 @@ curl -fsSL https://raw.githubusercontent.com/leeyudok/claude-scaffold/main/bin/c
 반영한다.
 
 ```bash
-claude-scaffold/bin/claude-scaffold.sh --update /path/to/existing-repo
+agents-scaffold/bin/agents-scaffold.sh --update /path/to/existing-repo
 ```
 
 - `.claude/hooks/pre-commit.sh` 는 스택 파셜이 삽입돼 있어 항상 건너뛴다(수동 병합 필요).
@@ -219,8 +219,8 @@ claude-scaffold/bin/claude-scaffold.sh --update /path/to/existing-repo
 새 프로젝트 생성 시 구성을 자동으로 깔리게 하는 법은 **[docs/GITLAB_TEMPLATE.md](docs/GITLAB_TEMPLATE.md)** 참조.
 
 > 주의: self-hosted GitLab 기준. **CE** 는 네이티브 커스텀 프로젝트 템플릿(Premium)이 불가.
-> CE 에서는 **Import by URL + `bin/claude-scaffold.sh`**(B안) 또는 **스크립트 단독**(C안)을 쓴다.
-> 생성/주입 후 `bin/claude-scaffold.sh .` 1회 실행 → 스택 적용 + 치환 + `bin/`·`presets/`·`docs/superpowers/` self-clean.
+> CE 에서는 **Import by URL + `bin/agents-scaffold.sh`**(B안) 또는 **스크립트 단독**(C안)을 쓴다.
+> 생성/주입 후 `bin/agents-scaffold.sh .` 1회 실행 → 스택 적용 + 치환 + `bin/`·`presets/`·`docs/superpowers/` self-clean.
 
 ## 치환 플레이스홀더
 
@@ -241,7 +241,7 @@ claude-scaffold/bin/claude-scaffold.sh --update /path/to/existing-repo
 ## Contributing
 
 워크플로는 [CONTRIBUTING.md](CONTRIBUTING.md), 스택 프리셋 규격은 [docs/PRESET_SPEC.md](docs/PRESET_SPEC.md) 참조.
-처음이라면 [`good first issue`](https://github.com/LeeYudok/claude-scaffold/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) 라벨부터 — 새 스택 프리셋 추가가 구조가 정형화돼 있어 가장 만만하다.
+처음이라면 [`good first issue`](https://github.com/LeeYudok/agents-scaffold/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) 라벨부터 — 새 스택 프리셋 추가가 구조가 정형화돼 있어 가장 만만하다.
 
 ## License
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -1,8 +1,8 @@
-# claude-scaffold
+# agents-scaffold
 
 [한국어](README.md) | [English](README.en.md) | 简体中文 | [日本語](README.ja.md)
 
-[![tests](https://github.com/leeyudok/claude-scaffold/actions/workflows/test.yml/badge.svg)](https://github.com/leeyudok/claude-scaffold/actions/workflows/test.yml)
+[![tests](https://github.com/leeyudok/agents-scaffold/actions/workflows/test.yml/badge.svg)](https://github.com/leeyudok/agents-scaffold/actions/workflows/test.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
 **这不是一个框架，而是一套极简的、fork 后按需填充的 Claude Code 引导脚手架**，
@@ -17,11 +17,11 @@ _30 秒演示：一条命令 → 填充完毕的 `.claude/` → 门禁拦截了�
 
 ```bash
 # 一条命令，无需 clone
-curl -fsSL https://raw.githubusercontent.com/leeyudok/claude-scaffold/main/bin/claude-scaffold.sh | bash -s -- --stack nextjs --yes
+curl -fsSL https://raw.githubusercontent.com/leeyudok/agents-scaffold/main/bin/agents-scaffold.sh | bash -s -- --stack nextjs --yes
 
 # 或从本地克隆运行（省略选项时会进入交互式提问）
-git clone https://github.com/leeyudok/claude-scaffold.git
-claude-scaffold/bin/claude-scaffold.sh /path/to/new-repo --forge github --stack nextjs,bun --name my-app
+git clone https://github.com/leeyudok/agents-scaffold.git
+agents-scaffold/bin/agents-scaffold.sh /path/to/new-repo --forge github --stack nextjs,bun --name my-app
 ```
 
 你将得到一个填充完毕的 `.claude/` 目录（agents、skills、hooks、按路径作用域加载的
@@ -58,9 +58,9 @@ prompt 编写也没关系：
 - **团队/多会话安全**：默认按会话隔离 git worktree，并行工作互不
   踩踏。
 
-## 为什么选择 claude-scaffold
+## 为什么选择 agents-scaffold
 
-与大型可安装框架或 agent/skill 目录不同，claude-scaffold 不附带运行时、
+与大型可安装框架或 agent/skill 目录不同，agents-scaffold 不附带运行时、
 不带插件系统、也没有需要保持同步的中心化 registry——它只是一个 `.claude/`
 目录骨架加上几个技术栈预设，复制进仓库一次之后就完全归你所有。日后没有
 任何东西需要升级：fork 它、填好占位符、删掉不需要的部分，最终得到的就是
@@ -124,7 +124,7 @@ presets/                  预设片段（复制覆盖模型）
   forge-gitlab/           GitLab forge —— glab、MR、`Closes #N` 自动关闭（合并后需确认）
   nextjs/ bun/ ...        各技术栈片段（规则 + pre-commit.partial.sh）
   lang-en/                英文覆盖层（base/forge-*/stacks/*）—— 见下文 `--lang`
-bin/                      claude-scaffold.sh 引导脚本
+bin/                      agents-scaffold.sh 引导脚本
 tests/                    引导脚本的 bats 回归测试套件
 ```
 
@@ -166,7 +166,7 @@ tests/                    引导脚本的 bats 回归测试套件
 覆盖同名文件。
 
 ```bash
-claude-scaffold/bin/claude-scaffold.sh /path/to/new-repo --lang en --forge github --stack bun
+agents-scaffold/bin/agents-scaffold.sh /path/to/new-repo --lang en --forge github --stack bun
 ```
 
 `.claude/hooks/pre-commit.sh` 永远不会被 `--lang` 覆盖（它是技术栈片段
@@ -177,9 +177,9 @@ claude-scaffold/bin/claude-scaffold.sh /path/to/new-repo --lang en --forge githu
 ## Usage 1 — 脚本
 
 ```bash
-git clone https://github.com/leeyudok/claude-scaffold.git
+git clone https://github.com/leeyudok/agents-scaffold.git
 # --forge 默认为 github；GitLab 仓库请用 --forge gitlab
-claude-scaffold/bin/claude-scaffold.sh /path/to/new-repo --forge github --stack nextjs,bun --name my-app
+agents-scaffold/bin/agents-scaffold.sh /path/to/new-repo --forge github --stack nextjs,bun --name my-app
 ```
 
 省略 `--forge`/`--stack`/`--name` 即进入交互模式——脚本会依次询问
@@ -200,13 +200,13 @@ claude-scaffold/bin/claude-scaffold.sh /path/to/new-repo --forge github --stack 
 ### 远程一键安装（无需 clone）
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/leeyudok/claude-scaffold/main/bin/claude-scaffold.sh | bash -s -- --stack nextjs --yes
+curl -fsSL https://raw.githubusercontent.com/leeyudok/agents-scaffold/main/bin/agents-scaffold.sh | bash -s -- --stack nextjs --yes
 ```
 
 当脚本检测到自己并非从本地检出运行时（例如管道执行），会将
-`CLAUDE_SCAFFOLD_REPO` 的 tarball（默认：
-`github.com/leeyudok/claude-scaffold`，可通过环境变量覆盖）下载到临时目录，
-并将其作为模板来源。用 `CLAUDE_SCAFFOLD_REF` 固定分支/标签
+`AGENTS_SCAFFOLD_REPO` 的 tarball（默认：
+`github.com/leeyudok/agents-scaffold`，可通过环境变量覆盖）下载到临时目录，
+并将其作为模板来源。用 `AGENTS_SCAFFOLD_REF` 固定分支/标签
 （默认 `main`）。
 
 ### 更新基础文件 — `--update`
@@ -215,7 +215,7 @@ curl -fsSL https://raw.githubusercontent.com/leeyudok/claude-scaffold/main/bin/c
 `GEMINI.md`）应用到已完成引导的项目。
 
 ```bash
-claude-scaffold/bin/claude-scaffold.sh --update /path/to/existing-repo
+agents-scaffold/bin/agents-scaffold.sh --update /path/to/existing-repo
 ```
 
 - `.claude/hooks/pre-commit.sh` 始终被跳过——技术栈片段已被拼接
@@ -232,8 +232,8 @@ claude-scaffold/bin/claude-scaffold.sh --update /path/to/existing-repo
 
 > 注意：该工作流假定使用自托管 GitLab 实例。在 **GitLab CE** 上，
 > 原生的自定义项目模板属于 Premium 功能、不可用——
-> 请改用 **Import by URL + `bin/claude-scaffold.sh`** 或**仅用脚本**。
-> 创建/导入后运行一次 `bin/claude-scaffold.sh .`，即可应用所选
+> 请改用 **Import by URL + `bin/agents-scaffold.sh`** 或**仅用脚本**。
+> 创建/导入后运行一次 `bin/agents-scaffold.sh .`，即可应用所选
 > 技术栈、替换占位符，并自清理 `bin/`/`presets/`/`docs/superpowers/`。
 
 ## 占位符替换
@@ -256,7 +256,7 @@ claude-scaffold/bin/claude-scaffold.sh --update /path/to/existing-repo
 
 工作流见 [CONTRIBUTING.md](CONTRIBUTING.md)，
 技术栈预设格式见 [docs/PRESET_SPEC.md](docs/PRESET_SPEC.md)。
-初来乍到？从 [`good first issue`](https://github.com/LeeYudok/claude-scaffold/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) 开始——
+初来乍到？从 [`good first issue`](https://github.com/LeeYudok/agents-scaffold/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) 开始——
 新增一个技术栈预设是最容易上手的任务，因为其结构已完全模板化。
 
 ## License

--- a/bin/agents-scaffold.sh
+++ b/bin/agents-scaffold.sh
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
-# claude-scaffold — .claude/ 부트스트랩.
+# agents-scaffold — .claude/ 부트스트랩.
 # P2 300줄 규칙 예외(#37): curl|bash 원커맨드 설치가 단일 파일을 요구해 분리하지 않는다.
 set -euo pipefail
 
 print_help() {
   cat <<'EOF'
 Usage:
-  bin/claude-scaffold.sh [<target-dir>] [--forge github|gitlab] [--stack nextjs,springboot] [--lang en|ko] [--name <project>] [--yes]
-  bin/claude-scaffold.sh --update [<target-dir>] [--name <project>]
-  curl -fsSL https://raw.githubusercontent.com/leeyudok/claude-scaffold/main/bin/claude-scaffold.sh | bash -s -- [--stack nextjs] [--name <project>] [--yes]
+  bin/agents-scaffold.sh [<target-dir>] [--forge github|gitlab] [--stack nextjs,springboot] [--lang en|ko] [--name <project>] [--yes]
+  bin/agents-scaffold.sh --update [<target-dir>] [--name <project>]
+  curl -fsSL https://raw.githubusercontent.com/leeyudok/agents-scaffold/main/bin/agents-scaffold.sh | bash -s -- [--stack nextjs] [--name <project>] [--yes]
 
   <target-dir>   Default "." (current directory). In-place (=repo itself) for the GitLab template path.
   --forge        Issue/PR forge. github (default) or gitlab. Interactive prompt if unset (default github).
@@ -27,10 +27,10 @@ Usage:
                  A summary of added/updated/skipped files is printed at the end.
 
 Remote install (no clone): if the local BASH_SOURCE-relative path is not a valid template
-root (e.g. running via curl pipe), a $CLAUDE_SCAFFOLD_REPO tarball is downloaded to a temp
+root (e.g. running via curl pipe), a $AGENTS_SCAFFOLD_REPO tarball is downloaded to a temp
 directory and used as the template source.
-  CLAUDE_SCAFFOLD_REPO  Defaults to the official GitHub repo URL (override via env).
-  CLAUDE_SCAFFOLD_REF   Branch/tag. Default "main".
+  AGENTS_SCAFFOLD_REPO  Defaults to the official GitHub repo URL (override via env).
+  AGENTS_SCAFFOLD_REF   Branch/tag. Default "main".
 
 Flow: copy base (.claude/ + CLAUDE.md) -> merge forge preset -> merge selected stack presets
       -> merge lang-en overlay (if --lang en) -> substitute {{PLACEHOLDER}} -> chmod +x
@@ -39,9 +39,9 @@ EOF
 }
 
 # 이슈 #10/#21: 원격 설치 기본 소스 레포
-CLAUDE_SCAFFOLD_REPO_OWNER_DEFAULT="leeyudok"
-CLAUDE_SCAFFOLD_REPO="${CLAUDE_SCAFFOLD_REPO:-https://github.com/${CLAUDE_SCAFFOLD_REPO_OWNER_DEFAULT}/claude-scaffold}"
-CLAUDE_SCAFFOLD_REF="${CLAUDE_SCAFFOLD_REF:-main}"
+AGENTS_SCAFFOLD_REPO_OWNER_DEFAULT="leeyudok"
+AGENTS_SCAFFOLD_REPO="${AGENTS_SCAFFOLD_REPO:-https://github.com/${AGENTS_SCAFFOLD_REPO_OWNER_DEFAULT}/agents-scaffold}"
+AGENTS_SCAFFOLD_REF="${AGENTS_SCAFFOLD_REF:-main}"
 
 TARGET="."
 STACKS=""
@@ -82,11 +82,11 @@ trap cleanup_remote_tmpdir EXIT
 
 fetch_remote_src() {
   REMOTE_TMPDIR="$(mktemp -d)"
-  local tarball="$REMOTE_TMPDIR/claude-scaffold.tar.gz"
-  local url="${CLAUDE_SCAFFOLD_REPO}/archive/refs/heads/${CLAUDE_SCAFFOLD_REF}.tar.gz"
+  local tarball="$REMOTE_TMPDIR/agents-scaffold.tar.gz"
+  local url="${AGENTS_SCAFFOLD_REPO}/archive/refs/heads/${AGENTS_SCAFFOLD_REF}.tar.gz"
   echo "== Local template not found — remote install: downloading $url ==" >&2
   if ! curl -fsSL "$url" -o "$tarball"; then
-    echo "Error: template download failed ($url). Check CLAUDE_SCAFFOLD_REPO/CLAUDE_SCAFFOLD_REF." >&2
+    echo "Error: template download failed ($url). Check AGENTS_SCAFFOLD_REPO/AGENTS_SCAFFOLD_REF." >&2
     exit 1
   fi
   tar -xzf "$tarball" -C "$REMOTE_TMPDIR"
@@ -135,7 +135,7 @@ substitute_placeholders() {
 
 # --- 이슈 #13: --update 모드. 이미 부트스트랩된 프로젝트의 베이스 파일을 최신화한다.
 run_update() {
-  echo "== claude-scaffold --update: target=$TARGET name=$NAME ==" >&2
+  echo "== agents-scaffold --update: target=$TARGET name=$NAME ==" >&2
   echo "note: --lang is out of scope for --update; only the Korean base is refreshed" >&2
 
   local hook_rel=".claude/hooks/pre-commit.sh"
@@ -247,7 +247,7 @@ if [ -z "$STACKS" ] && [ "$ASSUME_YES" -eq 0 ] && [ -t 0 ]; then
   read -r STACKS || STACKS=""
 fi
 
-echo "== claude-scaffold: target=$TARGET name=$NAME forge=$FORGE stacks=[${STACKS:-none}] lang=$LANG_OPT inplace=$INPLACE ==" >&2
+echo "== agents-scaffold: target=$TARGET name=$NAME forge=$FORGE stacks=[${STACKS:-none}] lang=$LANG_OPT inplace=$INPLACE ==" >&2
 
 # 1) 베이스 복사 (in-place 면 이미 있으므로 스킵)
 # git 소스면 tracked 파일만 복사(#39) — cp -R 은 untracked 로컬 산출물

--- a/docs/ECC_MANIFESTS.md
+++ b/docs/ECC_MANIFESTS.md
@@ -1,7 +1,7 @@
 # ECC manifests 구조 분석 — 프리셋 확장 시 참고
 
 > 출처: ECC([affaan-m/ECC](https://github.com/affaan-m/ECC), MIT) `manifests/` (2026-07-09 스냅샷).
-> claude-scaffold 프리셋(현 10종 스택 + forge 2종)이 더 늘어나 "스택 = 프리셋 1개" 평면 구조가
+> agents-scaffold 프리셋(현 10종 스택 + forge 2종)이 더 늘어나 "스택 = 프리셋 1개" 평면 구조가
 > 버거워질 때 참고할 선택 설치 설계. **지금 당장 도입하는 것 아님** — 임계점은 아래 "도입 판단" 참조.
 
 ## 3계층 모델
@@ -29,9 +29,9 @@ profiles (7종)  ──펼침──▶  modules (33종)  ◀──참조──  
 - **components 는 UX 레이어**: 여러 별칭(`lang:typescript`, `framework:react`)이 같은 모듈
   (`framework-language`)로 수렴 — 사용자 언어와 설치 단위를 분리.
 
-## claude-scaffold 현행과 대응
+## agents-scaffold 현행과 대응
 
-| ECC | claude-scaffold 현행 | 비고 |
+| ECC | agents-scaffold 현행 | 비고 |
 |---|---|---|
 | profile | 없음 (전 스택 공통 base + `--stack` 나열) | base `.claude/` 가 사실상 단일 core 프로파일 |
 | module | `presets/<stack>/` 디렉터리 | 의존성·비용 메타데이터 없음, 경로 규약(`rules/<stack>.md` + `pre-commit.partial.sh`)이 암묵 스키마 |
@@ -48,10 +48,10 @@ profiles (7종)  ──펼침──▶  modules (33종)  ◀──참조──  
 
 도입 시 최소안: `presets/manifest.json` 1개 파일로 시작
 (`{id, description, dependencies[], cost}` 만 — profiles/components 분리는 그 다음 단계),
-`bin/claude-scaffold.sh` 의 스택 머지 루프 앞에 의존성 펼침만 추가.
+`bin/agents-scaffold.sh` 의 스택 머지 루프 앞에 의존성 펼침만 추가.
 
 ## 반면교사
 
-- ECC 는 매니페스트 3개 + 인스톨러 JS(수백 줄)를 스스로 유지보수 — claude-scaffold 규모(프리셋 10종)에
+- ECC 는 매니페스트 3개 + 인스톨러 JS(수백 줄)를 스스로 유지보수 — agents-scaffold 규모(프리셋 10종)에
   이 복잡도를 미리 들여오면 배보다 배꼽. **필요 신호 전 도입 금지.**
 - `defaultInstall: true` 모듈이 늘면 "minimal" 이 무거워지는 drift — 프로파일별 스냅샷 테스트가 없으면 조용히 비대해진다.

--- a/docs/GITLAB_TEMPLATE.md
+++ b/docs/GITLAB_TEMPLATE.md
@@ -1,6 +1,6 @@
-# claude-scaffold 을 GitLab 템플릿으로 쓰기
+# agents-scaffold 을 GitLab 템플릿으로 쓰기
 
-새 프로젝트를 만들 때 claude-scaffold 구성을 자동으로 깔리게 하는 방법.
+새 프로젝트를 만들 때 agents-scaffold 구성을 자동으로 깔리게 하는 방법.
 
 > **에디션별 요약**
 > 네이티브 **커스텀 프로젝트 템플릿**(아래 A안)은 **Premium/Enterprise 전용**이라 **Community Edition(CE)** 에선 메뉴가 없다.
@@ -12,58 +12,58 @@
 
 Premium 이상에서만 동작. 향후 라이선스 업그레이드 시 사용.
 
-전제: 템플릿 프로젝트는 **서브그룹** 안에 있어야 한다. claude-scaffold 을 예컨대 `<group>/templates/claude-scaffold` 으로 옮긴다.
+전제: 템플릿 프로젝트는 **서브그룹** 안에 있어야 한다. agents-scaffold 을 예컨대 `<group>/templates/agents-scaffold` 으로 옮긴다.
 
 ### 그룹 레벨 등록
 1. `<group>` 그룹 → **Settings → General → Custom project templates** 펼치기.
 2. 템플릿 소스로 서브그룹(`<group>/templates`) 선택 → 저장.
-3. 새 프로젝트 생성 시 **Create from template → Group** 탭에 `claude-scaffold` 이 노출됨.
+3. 새 프로젝트 생성 시 **Create from template → Group** 탭에 `agents-scaffold` 이 노출됨.
 
 ### 인스턴스 레벨 등록(전 그룹 공용, admin 필요)
 1. **Admin Area → Settings → Templates → Custom project templates**.
 2. 템플릿 프로젝트가 모인 그룹 지정 → 저장.
 3. 모든 새 프로젝트의 **Create from template → Instance** 탭에 노출.
 
-> 두 경로 모두 프로젝트 전체(=claude-scaffold 의 `bin/`·`presets/`·`docs/` 포함)가 복제된다.
-> 생성 후 반드시 `bin/claude-scaffold.sh .` 를 1회 실행해 스택 적용 + 플레이스홀더 치환 + self-clean 한다.
+> 두 경로 모두 프로젝트 전체(=agents-scaffold 의 `bin/`·`presets/`·`docs/` 포함)가 복제된다.
+> 생성 후 반드시 `bin/agents-scaffold.sh .` 를 1회 실행해 스택 적용 + 플레이스홀더 치환 + self-clean 한다.
 
 ---
 
 ## B안 — Import by URL + 스크립트 (CE 에서 권장)
 
-CE 에서 "템플릿"에 가장 가까운 방법. 새 프로젝트에 claude-scaffold 내용을 그대로 가져온 뒤 마무리한다.
+CE 에서 "템플릿"에 가장 가까운 방법. 새 프로젝트에 agents-scaffold 내용을 그대로 가져온 뒤 마무리한다.
 
 1. **New project → Import project → Repository by URL**.
-2. Git repository URL 에 claude-scaffold 주소 입력:
-   `https://<your-gitlab-host>/<group>/claude-scaffold.git`
+2. Git repository URL 에 agents-scaffold 주소 입력:
+   `https://<your-gitlab-host>/<group>/agents-scaffold.git`
    (프로젝트 이름·네임스페이스는 새 프로젝트 것으로 지정)
 3. import 완료 후 로컬에 clone, 부트스트랩 1회 실행:
    ```bash
    git clone git@<your-gitlab-host>:<group>/<new-repo>.git
    cd <new-repo>
-   bin/claude-scaffold.sh . --stack nextjs,springboot --name <new-repo>
-   git add -A && git commit -m "chore: claude-scaffold 부트스트랩"
+   bin/agents-scaffold.sh . --stack nextjs,springboot --name <new-repo>
+   git add -A && git commit -m "chore: agents-scaffold 부트스트랩"
    git push
    ```
-   `bin/claude-scaffold.sh .` 는 in-place 모드 → 스택 적용 + 치환 + `bin/`·`presets/`·`docs/superpowers/` self-clean.
+   `bin/agents-scaffold.sh .` 는 in-place 모드 → 스택 적용 + 치환 + `bin/`·`presets/`·`docs/superpowers/` self-clean.
 
-> import 는 claude-scaffold 의 git 히스토리도 가져온다. 깨끗이 시작하려면 import 대신 C안을 쓴다.
+> import 는 agents-scaffold 의 git 히스토리도 가져온다. 깨끗이 시작하려면 import 대신 C안을 쓴다.
 
 ---
 
 ## C안 — 스크립트 단독 (히스토리 없이, 가장 단순)
 
-claude-scaffold 을 한 번 clone 해두고, 빈/기존 레포에 구성만 주입한다.
+agents-scaffold 을 한 번 clone 해두고, 빈/기존 레포에 구성만 주입한다.
 
 ```bash
-# claude-scaffold 은 한 번만 받아두면 됨
-git clone git@<your-gitlab-host>:<group>/claude-scaffold.git ~/claude-scaffold
+# agents-scaffold 은 한 번만 받아두면 됨
+git clone git@<your-gitlab-host>:<group>/agents-scaffold.git ~/agents-scaffold
 
 # 새 레포 디렉터리에 구성 주입
-~/claude-scaffold/bin/claude-scaffold.sh /path/to/new-repo --stack springboot --name my-app
+~/agents-scaffold/bin/agents-scaffold.sh /path/to/new-repo --stack springboot --name my-app
 ```
 
-대상이 claude-scaffold 자신이 아니므로 self-clean 은 일어나지 않고, 베이스 `.claude/` + 선택 스택만 복사된다.
+대상이 agents-scaffold 자신이 아니므로 self-clean 은 일어나지 않고, 베이스 `.claude/` + 선택 스택만 복사된다.
 
 ---
 

--- a/docs/PRESET_SPEC.md
+++ b/docs/PRESET_SPEC.md
@@ -1,6 +1,6 @@
 # 스택 프리셋 명세
 
-이 문서는 `bin/claude-scaffold.sh` 가 소비하는 `presets/<stack>/` 하위 스택 프리셋의
+이 문서는 `bin/agents-scaffold.sh` 가 소비하는 `presets/<stack>/` 하위 스택 프리셋의
 필수 레이아웃과 동작을 정의한다. 신규 프리셋을 추가하거나 기존 프리셋을 감사하는
 사람을 위한 레퍼런스이며 — 여기를 가리키는 기여 워크플로는 `CONTRIBUTING.md` 참조.
 
@@ -53,7 +53,7 @@ presets/<stack>/
 
 ## `pre-commit.partial.sh` 계약
 
-`bin/claude-scaffold.sh` 는 선택된 각 스택의 파셜을 대상의
+`bin/agents-scaffold.sh` 는 선택된 각 스택의 파셜을 대상의
 `.claude/hooks/pre-commit.sh` 안 `# --- STACK CHECKS` 마커 줄 바로 뒤에,
 `--stack` 에 전달된 순서대로 삽입한다. 여러 파셜은 하나의 파일 안에 이어
 붙어서, 베이스 스크립트의 끝부분 `echo "pre-commit 통과"; exit 0` 이전까지
@@ -114,7 +114,7 @@ presets/<stack>/
 | `{{PROJECT_NAME}}` | `--name` 값, 또는 대상 디렉터리의 basename |
 | `{{JAVA_VERSION}}` | `1.8`(현재 유일한 스택 고유 플레이스홀더, `springboot` 가 사용) |
 
-새 프리셋에 스택 고유 플레이스홀더가 필요하면 `bin/claude-scaffold.sh` 3단계의
+새 프리셋에 스택 고유 플레이스홀더가 필요하면 `bin/agents-scaffold.sh` 3단계의
 `sed` 호출에 치환을 추가하고, 여기와 `README.md` 의 플레이스홀더 표에도
 문서화한다 — 스크립트가 채울 방법을 모르는 임의 토큰을 만들지 말 것.
 
@@ -169,7 +169,7 @@ presets/lang-en/
 - [ ] `presets/<stack>/.claude/rules/<stack>.md` 의 영어 대응물로
       `presets/lang-en/stacks/<stack>/.claude/rules/<stack>.md` 가
       추가됐다.
-- [ ] `bin/claude-scaffold.sh <dir> --stack <stack> --name scratch` 로 스크래치
+- [ ] `bin/agents-scaffold.sh <dir> --stack <stack> --name scratch` 로 스크래치
       레포를 부트스트랩해 다음을 확인했다:
   - 룰 파일이 플레이스홀더가 치환된 채로 `.claude/rules/<stack>.md` 에
     안착한다,

--- a/docs/superpowers/specs/2026-06-30-claude-init-template-design.md
+++ b/docs/superpowers/specs/2026-06-30-claude-init-template-design.md
@@ -1,11 +1,11 @@
-# claude-scaffold 템플릿 — 설계 (2026-06-30, 이슈 #1)
+# agents-scaffold 템플릿 — 설계 (2026-06-30, 이슈 #1)
 
 ## 목적
 
-새 레포를 만들 때마다 `.claude/` 협업 구성을 손으로 다시 짜지 않도록, **부트스트랩 템플릿**을 한 곳(`<group>/claude-scaffold`)에 둔다. 두 경로로 소비한다:
+새 레포를 만들 때마다 `.claude/` 협업 구성을 손으로 다시 짜지 않도록, **부트스트랩 템플릿**을 한 곳(`<group>/agents-scaffold`)에 둔다. 두 경로로 소비한다:
 
-1. **스크립트** — `bin/claude-scaffold.sh <target-dir>` 실행 → 베이스 + 선택 스택 프리셋 복사 + 플레이스홀더 치환.
-2. **GitLab 프로젝트 템플릿** — 그룹 템플릿으로 등록 → "Create from template" → 생성 후 `bin/claude-scaffold.sh` 1회 실행으로 마무리(스택 적용·치환·self-clean).
+1. **스크립트** — `bin/agents-scaffold.sh <target-dir>` 실행 → 베이스 + 선택 스택 프리셋 복사 + 플레이스홀더 치환.
+2. **GitLab 프로젝트 템플릿** — 그룹 템플릿으로 등록 → "Create from template" → 생성 후 `bin/agents-scaffold.sh` 1회 실행으로 마무리(스택 적용·치환·self-clean).
 
 ## 비목표 (YAGNI)
 
@@ -16,10 +16,10 @@
 ## 레이아웃
 
 ```
-claude-scaffold/
+agents-scaffold/
 ├── README.md                      # 용도·사용법(스크립트/템플릿 두 경로)
 ├── bin/
-│   └── claude-scaffold.sh             # 부트스트랩 엔트리
+│   └── agents-scaffold.sh             # 부트스트랩 엔트리
 ├── presets/                       # 스택별 조각(스크립트가 선택 복사)
 │   ├── nextjs/
 │   │   └── .claude/rules/nextjs.md         # paths: app/**,components/**
@@ -40,14 +40,14 @@ claude-scaffold/
 
 ## 컴포넌트 사양
 
-### bin/claude-scaffold.sh
+### bin/agents-scaffold.sh
 - 인자: `<target-dir>`(기본 `.`), 옵션 `--stack nextjs,springboot`(미지정 시 대화형 프롬프트), `--name <project>`.
 - 동작:
   1. 베이스 `.claude/` + `CLAUDE.md`를 target에 복사(기존 파일 있으면 덮어쓰기 전 확인).
   2. 선택 스택별 `presets/<stack>/` 내용을 target에 머지(rule 추가, `pre-commit.partial.sh`는 `.claude/hooks/pre-commit.sh`에 append).
   3. 플레이스홀더 치환: `{{PROJECT_NAME}}`(→ --name 또는 target 디렉터리명), `{{JAVA_VERSION}}`(springboot 선택 시 `1.8`).
   4. `.sh` 실행권한 부여.
-  5. **self-clean**: target이 곧 claude-scaffold 자신일 때(GitLab 템플릿 경로)면 `bin/`·`presets/`·`docs/superpowers/`를 제거하고 자기 자신도 정리.
+  5. **self-clean**: target이 곧 agents-scaffold 자신일 때(GitLab 템플릿 경로)면 `bin/`·`presets/`·`docs/superpowers/`를 제거하고 자기 자신도 정리.
 - 순수 bash + 표준 유틸(cp/sed/find)만. 외부 의존 없음.
 
 ### .claude/settings.json (베이스, 실동작)
@@ -81,6 +81,6 @@ claude-scaffold/
 
 ## 검증
 
-- `bin/claude-scaffold.sh`를 빈 임시 디렉터리에 실행 → `.claude/` 구조·치환·실행권한 확인.
+- `bin/agents-scaffold.sh`를 빈 임시 디렉터리에 실행 → `.claude/` 구조·치환·실행권한 확인.
 - nextjs/springboot 각각 선택 시 해당 rule이 들어오고 paths frontmatter 유효(YAML) 확인.
 - settings.json JSON 유효성, rule md frontmatter 파싱 가능 확인.

--- a/tests/agents-scaffold.bats
+++ b/tests/agents-scaffold.bats
@@ -1,17 +1,17 @@
 #!/usr/bin/env bats
-# claude-scaffold.sh 회귀 테스트 (이슈 #12)
+# agents-scaffold.sh 회귀 테스트 (이슈 #12)
 #
-# 실행: bats tests/claude-scaffold.bats
+# 실행: bats tests/agents-scaffold.bats
 # 로컬 설치: brew install bats-core (또는 https://github.com/bats-core/bats-core)
 #
-# 각 테스트는 REPO_ROOT/bin/claude-scaffold.sh 를 BATS_TEST_TMPDIR 안의
+# 각 테스트는 REPO_ROOT/bin/agents-scaffold.sh 를 BATS_TEST_TMPDIR 안의
 # 격리된 타겟에 대해 실행한다. 원본 레포는 절대 건드리지 않는다
 # (in-place self-clean 테스트만 예외 — 반드시 레포를 임시 복사한 사본을 대상으로 함).
 #
-# ⚠️ 알려진 환경 이슈 (이슈 #12 조사 중 발견, bin/claude-scaffold.sh 는 수정하지 않음
+# ⚠️ 알려진 환경 이슈 (이슈 #12 조사 중 발견, bin/agents-scaffold.sh 는 수정하지 않음
 #    — #10/#13 병렬 작업 범위): macOS 기본 시스템 bash(/bin/bash, 3.2, set -u 하에서
 #    "IFS=',' read -a arr <<< \"\"" 로 만든 빈 배열 참조 시 "unbound variable" 로 죽는
-#    구버전 버그 있음) 로 bin/claude-scaffold.sh 를 실행하면 --stack 을 지정하지 않은
+#    구버전 버그 있음) 로 bin/agents-scaffold.sh 를 실행하면 --stack 을 지정하지 않은
 #    호출(예: base copy 전용 실행)이 90번째 줄 `for s in "${STACK_ARR[@]}"` 에서
 #    실패한다. bash>=4 (CI ubuntu 기본, 또는 `brew install bash` 후 PATH 우선순위 조정)
 #    에서는 재현되지 않는다. 이 테스트 스위트는 CI/최신 bash 기준으로 통과하도록
@@ -20,7 +20,7 @@
 
 setup() {
   REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
-  SCRIPT="$REPO_ROOT/bin/claude-scaffold.sh"
+  SCRIPT="$REPO_ROOT/bin/agents-scaffold.sh"
 }
 
 # --- 1) 베이스 복사 ---
@@ -162,7 +162,7 @@ EOF
   cp -R "$REPO_ROOT" "$copy"
 
   # 원본 레포는 훼손되지 않아야 하므로 사본 경로로만 실행
-  run "$copy/bin/claude-scaffold.sh" "$copy" --yes
+  run "$copy/bin/agents-scaffold.sh" "$copy" --yes
   [ "$status" -eq 0 ]
 
   [ ! -d "$copy/bin" ]
@@ -199,7 +199,7 @@ EOF
 
   target="$BATS_TEST_TMPDIR/lang-en-target"
   mkdir -p "$target"
-  run "$copy/bin/claude-scaffold.sh" "$target" --lang en --yes
+  run "$copy/bin/agents-scaffold.sh" "$target" --lang en --yes
   [ "$status" -eq 0 ]
 
   [ -f "$target/.claude/rules/common.md" ]
@@ -215,7 +215,7 @@ EOF
 
   target="$BATS_TEST_TMPDIR/lang-default-target"
   mkdir -p "$target"
-  run "$copy/bin/claude-scaffold.sh" "$target" --yes
+  run "$copy/bin/agents-scaffold.sh" "$target" --yes
   [ "$status" -eq 0 ]
 
   [ -f "$target/.claude/rules/common.md" ]
@@ -461,7 +461,7 @@ setup_publish_repo() {
 
   target="$BATS_TEST_TMPDIR/pyc-target"
   mkdir -p "$target"
-  run "$copy/bin/claude-scaffold.sh" "$target" --yes
+  run "$copy/bin/agents-scaffold.sh" "$target" --yes
   [ "$status" -eq 0 ]
   grep -q 'pyc-target' "$target/AGENTS.md"
   # untracked 바이너리는 아예 복사되지 않아야 한다(#39 git ls-files 기반 복사)


### PR DESCRIPTION
Part 1 of #16 (repo already renamed on GitHub; old URLs redirect).

- `bin/claude-scaffold.sh` → `bin/agents-scaffold.sh`, `tests/claude-scaffold.bats` → `tests/agents-scaffold.bats`
- 153 name/URL/env-var occurrences substituted across READMEs x4, CONTRIBUTING, CREDITS, templates, docs, CI (`CLAUDE_SCAFFOLD_*` → `AGENTS_SCAFFOLD_*`)
- No back-compat aliases — GitHub redirects handle old links

Verified: bats 31 + unittest 22 green, link checker 0 broken. Codex harness support follows as part 2.