### PR TITLE
feat(#16): --harness claude|codex|all — Codex support

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -158,6 +158,16 @@ Injected files: `.claude/rules/forge.md` (always loaded) plus forge variants of
 `.claude/commands/fix-issue.md` and `sdlc-cycle.md` (overwrite the base). Base
 files stay forge-neutral ("issue / PR·MR").
 
+## Harness (`--harness`)
+
+| Value | Target | What it does |
+|---|---|---|
+| `claude` (default) | Claude Code | Full install — settings.json hook bindings, subagents, slash commands, workflows |
+| `codex` | Codex and other AGENTS.md harnesses | Installs only the harness-neutral layers (AGENTS.md, rules, skills, hooks, memory), drops the Claude-only layers, and wires the pre-commit gate as a **real `.git/hooks/pre-commit`** |
+| `all` | Mixed teams | Full install + the git hook (Claude Code enforces via PreToolUse; every other harness hits the same gate through the git hook) |
+
+Codex reads `AGENTS.md` natively, so the rules layer works as-is. An existing `.git/hooks/pre-commit` is never overwritten — you get a warning instead.
+
 ## Language (`--lang`)
 
 The base tree (agents, rules, skills, commands, `AGENTS.md`, hook/settings

--- a/README.ja.md
+++ b/README.ja.md
@@ -158,6 +158,16 @@ tests/                    ブートストラップスクリプト用 bats リグ
 `.claude/commands/fix-issue.md` と `sdlc-cycle.md` の forge 別バリアント(ベースを上書き)。
 ベースファイルは forge 非依存のまま("issue / PR·MR")です。
 
+## ハーネス (`--harness`)
+
+| 値 | 対象 | 動作 |
+|---|---|---|
+| `claude`（デフォルト） | Claude Code | フルインストール — settings.json のフックバインディング・サブエージェント・スラッシュコマンド・workflows を含む |
+| `codex` | Codex ほか AGENTS.md 対応ハーネス | ハーネス中立の層（AGENTS.md・rules・skills・hooks・memory）のみ導入し、Claude 専用層を除去。pre-commit ゲートを**実際の `.git/hooks/pre-commit`** に配線 |
+| `all` | 混在チーム | フルインストール + git フック（Claude Code は PreToolUse、他ハーネスは git フック経由で同じゲートを通る） |
+
+Codex は `AGENTS.md` をネイティブに読むため、ルール層はそのまま機能します。既存の `.git/hooks/pre-commit` は上書きせず、警告のみ出します。
+
 ## 言語 (`--lang`)
 
 ベースツリー(エージェント、ルール、スキル、コマンド、`AGENTS.md`、フック/settings の

--- a/README.md
+++ b/README.md
@@ -151,6 +151,16 @@ bin/                    agents-scaffold.sh 부트스트랩 스크립트
 
 주입 파일: `.claude/rules/forge.md`(항상 로드) + `.claude/commands/fix-issue.md`·`sdlc-cycle.md`(forge 변형으로 덮어씀). 베이스 파일은 forge 중립("이슈/PR·MR").
 
+## 하네스 (`--harness`)
+
+| 값 | 대상 | 하는 일 |
+|---|---|---|
+| `claude` (기본) | Claude Code | 전체 설치 — settings.json 훅 바인딩·서브에이전트·슬래시 커맨드·workflows 포함 |
+| `codex` | Codex 등 AGENTS.md 하네스 | 하네스 중립 계층(AGENTS.md·rules·skills·hooks·memory)만 설치, Claude 전용 계층 제거, pre-commit 게이트를 **진짜 `.git/hooks/pre-commit`** 으로 배선 |
+| `all` | 혼용 팀 | 전체 설치 + git hook 배선 (Claude Code 는 PreToolUse, 그 외 하네스는 git hook 으로 같은 게이트를 탄다) |
+
+Codex 는 `AGENTS.md` 를 네이티브로 읽으므로 규칙 계층은 그대로 동작한다. 기존 `.git/hooks/pre-commit` 이 있으면 덮어쓰지 않고 경고만 낸다.
+
 ## 언어 (`--lang`)
 
 베이스 트리(agents·rules·skills·commands·`AGENTS.md`·훅/settings 메시지)는 **기본이

--- a/README.zh.md
+++ b/README.zh.md
@@ -156,6 +156,16 @@ tests/                    引导脚本的 bats 回归测试套件
 `.claude/commands/fix-issue.md` 和 `sdlc-cycle.md` 的 forge 变体（覆盖基础版本）。
 基础文件保持 forge 中立（"issue / PR·MR"）。
 
+## Harness（`--harness`）
+
+| 取值 | 目标 | 行为 |
+|---|---|---|
+| `claude`（默认） | Claude Code | 完整安装 — 含 settings.json 钩子绑定、子代理、斜杠命令、workflows |
+| `codex` | Codex 及其他 AGENTS.md harness | 仅安装与 harness 无关的层（AGENTS.md、rules、skills、hooks、memory），移除 Claude 专用层，并把 pre-commit 门禁接入**真正的 `.git/hooks/pre-commit`** |
+| `all` | 混合团队 | 完整安装 + git 钩子（Claude Code 走 PreToolUse，其余 harness 通过 git 钩子经过同一道门禁） |
+
+Codex 原生读取 `AGENTS.md`，规则层可直接生效。已存在的 `.git/hooks/pre-commit` 不会被覆盖，只会给出警告。
+
 ## 语言（`--lang`）
 
 基础目录树（agents、rules、skills、commands、`AGENTS.md`、钩子/settings

--- a/bin/agents-scaffold.sh
+++ b/bin/agents-scaffold.sh
@@ -17,6 +17,12 @@ Usage:
                  en overlays presets/lang-en/ (base + forge + selected stacks) on top of the
                  English base, after base copy + forge merge + stack merge.
   --name         {{PROJECT_NAME}} substitution value. Default = target directory name.
+  --harness      Target agent harness: claude (default), codex, or all.
+                 codex keeps AGENTS.md + rules/skills/hooks/memory (harness-neutral),
+                 drops Claude Code-only layers (settings.json, agents/, commands/,
+                 workflows/, CLAUDE.md/GEMINI.md pointers), and wires the pre-commit
+                 gate as a real .git/hooks/pre-commit. all installs everything and
+                 also wires the git hook.
   --yes          Skip interactive prompts (non-interactive mode).
   --update       Refresh the base .claude/·AGENTS.md etc. of an already-bootstrapped project.
                  .claude/hooks/pre-commit.sh has stack partials inserted, so it is skipped
@@ -50,6 +56,7 @@ LANG_OPT=""
 NAME=""
 ASSUME_YES=0
 UPDATE=0
+HARNESS="claude"
 
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -57,6 +64,7 @@ while [ $# -gt 0 ]; do
     --forge) FORGE="$2"; shift 2 ;;
     --lang)  LANG_OPT="$2"; shift 2 ;;
     --name)  NAME="$2";  shift 2 ;;
+    --harness) HARNESS="$2"; shift 2 ;;
     --yes)   ASSUME_YES=1; shift ;;
     --update) UPDATE=1; shift ;;
     -h|--help) print_help; exit 0 ;;
@@ -67,6 +75,11 @@ done
 
 TARGET="$(cd "$TARGET" && pwd)"
 [ -z "$NAME" ] && NAME="$(basename "$TARGET")"
+
+case "$HARNESS" in
+  claude|codex|all) ;;
+  *) echo "Unknown --harness '$HARNESS' (claude|codex|all)" >&2; exit 1 ;;
+esac
 
 # --- 이슈 #10: SRC 결정. 로컬 clone 이면 BASH_SOURCE 기준, curl 파이프 등으로
 #     로컬 템플릿이 없으면 tarball 을 받아 임시 디렉터리를 SRC 로 쓴다.
@@ -375,6 +388,32 @@ done
 
 # 4) 실행권한
 chmod +x "$TARGET/.claude/hooks/"*.sh 2>/dev/null || true
+
+# 4.5) 하네스 조정 (#16)
+#   codex: Claude Code 전용 계층 제거 — AGENTS.md 는 Codex 가 네이티브로 읽고,
+#          rules/skills/hooks/memory 는 하네스 중립 문서·스크립트라 유지한다.
+#   codex|all: pre-commit 게이트를 진짜 git hook 으로도 배선 — Claude Code 의
+#          PreToolUse 바인딩(settings.json)이 없는 하네스에서도 강제가 성립.
+if [ "$HARNESS" = "codex" ]; then
+  echo "== harness=codex: removing Claude Code-only layers ==" >&2
+  rm -rf "$TARGET/.claude/agents" "$TARGET/.claude/commands" "$TARGET/.claude/workflows"
+  rm -f "$TARGET/.claude/settings.json" "$TARGET/CLAUDE.md" "$TARGET/GEMINI.md"
+fi
+if [ "$HARNESS" = "codex" ] || [ "$HARNESS" = "all" ]; then
+  if [ -d "$TARGET/.git" ]; then
+    githook="$TARGET/.git/hooks/pre-commit"
+    if [ -e "$githook" ]; then
+      echo "Warning: .git/hooks/pre-commit already exists — not overwriting. Chain .claude/hooks/pre-commit.sh manually." >&2
+    else
+      printf '%s\n' '#!/usr/bin/env bash' 'exec "$(git rev-parse --show-toplevel)/.claude/hooks/pre-commit.sh"' > "$githook"
+      chmod +x "$githook"
+      echo "== git pre-commit hook wired to .claude/hooks/pre-commit.sh ==" >&2
+    fi
+  else
+    echo "Note: target is not a git repo yet — after 'git init', wire the gate with:" >&2
+    echo "  printf '%s\n' '#!/usr/bin/env bash' 'exec \"\$(git rev-parse --show-toplevel)/.claude/hooks/pre-commit.sh\"' > .git/hooks/pre-commit && chmod +x .git/hooks/pre-commit" >&2
+  fi
+fi
 
 # 5) in-place self-clean (템플릿 흔적 제거)
 if [ "$INPLACE" -eq 1 ]; then

--- a/tests/agents-scaffold.bats
+++ b/tests/agents-scaffold.bats
@@ -512,3 +512,55 @@ JSP
   [ "$status" -eq 2 ]
   [[ "$output" == *"스크립틀릿"* ]]
 }
+
+# --- 9) harness (#16) ---
+
+@test "harness codex drops Claude-only layers, keeps neutral ones, wires git hook" {
+  t="$BATS_TEST_TMPDIR/codex"
+  mkdir -p "$t"
+  git -C "$t" init -q
+  run bash "$SCRIPT" "$t" --forge github --stack go --harness codex --name codex-app --yes
+  [ "$status" -eq 0 ]
+  # kept: harness-neutral layers
+  [ -f "$t/AGENTS.md" ]
+  [ -f "$t/.claude/rules/go.md" ]
+  [ -d "$t/.claude/skills" ]
+  [ -f "$t/.claude/hooks/pre-commit.sh" ]
+  # dropped: Claude Code-only layers
+  [ ! -e "$t/.claude/settings.json" ]
+  [ ! -d "$t/.claude/agents" ]
+  [ ! -d "$t/.claude/commands" ]
+  [ ! -d "$t/.claude/workflows" ]
+  [ ! -e "$t/CLAUDE.md" ]
+  [ ! -e "$t/GEMINI.md" ]
+  # git hook wired and executable, chains the gate
+  [ -x "$t/.git/hooks/pre-commit" ]
+  grep -q 'pre-commit.sh' "$t/.git/hooks/pre-commit"
+  # the wired gate actually blocks a staged .env
+  cd "$t"
+  echo 'X=1' > .env
+  git add -f .env
+  run bash .git/hooks/pre-commit
+  [ "$status" -eq 2 ]
+}
+
+@test "harness all keeps everything and wires git hook; default claude does not touch .git/hooks" {
+  t="$BATS_TEST_TMPDIR/allmode"
+  mkdir -p "$t"
+  git -C "$t" init -q
+  run bash "$SCRIPT" "$t" --forge github --harness all --name all-app --yes
+  [ "$status" -eq 0 ]
+  [ -f "$t/.claude/settings.json" ]
+  [ -f "$t/CLAUDE.md" ]
+  [ -x "$t/.git/hooks/pre-commit" ]
+
+  t2="$BATS_TEST_TMPDIR/claudemode"
+  mkdir -p "$t2"
+  git -C "$t2" init -q
+  run bash "$SCRIPT" "$t2" --forge github --name claude-app --yes
+  [ "$status" -eq 0 ]
+  [ ! -e "$t2/.git/hooks/pre-commit" ]
+
+  run bash "$SCRIPT" "$BATS_TEST_TMPDIR" --harness nope --yes
+  [ "$status" -eq 1 ]
+}


### PR DESCRIPTION
Closes #16 (part 2; the rename landed in #17).

Adds `--harness claude|codex|all` (default `claude`) to `bin/agents-scaffold.sh`:

- **codex**: installs only the harness-neutral layers — `AGENTS.md` (read natively by Codex), `rules/`, `skills/`, `hooks/`, `memory/` — drops the Claude Code-only layers (settings.json, agents/, commands/, workflows/, CLAUDE.md/GEMINI.md pointers), and wires the pre-commit gate as a real `.git/hooks/pre-commit` so enforcement works without Claude Code's PreToolUse binding
- **all**: full install + the git hook, for teams mixing harnesses
- existing `.git/hooks/pre-commit` is never overwritten (warning instead); non-git targets get a copy-paste wiring instruction
- Harness section documented in all four READMEs; 2 new bats tests (33 total, incl. an end-to-end check that the wired git hook blocks a staged `.env`)