### PR TITLE
docs: harness verification results + multi-harness intro

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -5,9 +5,10 @@
 [![tests](https://github.com/leeyudok/agents-scaffold/actions/workflows/test.yml/badge.svg)](https://github.com/leeyudok/agents-scaffold/actions/workflows/test.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
-**Not a framework — a minimal, fork-and-fill bootstrap for Claude Code** with
+**Not a framework — a minimal, fork-and-fill bootstrap for AI coding agents** with
 **enforced** rule tiers: P0 (halt) / P1 (PR-block) / P2 (review). Stack presets
-compose into a single pre-commit gate.
+compose into a single pre-commit gate. Claude Code first; Codex and other
+AGENTS.md harnesses are supported via [`--harness`](#harness---harness).
 
 ![Demo: one-command bootstrap, the generated .claude/ tree, and the pre-commit gate blocking a staged .env](docs/assets/demo.gif)
 
@@ -167,6 +168,8 @@ files stay forge-neutral ("issue / PR·MR").
 | `all` | Mixed teams | Full install + the git hook (Claude Code enforces via PreToolUse; every other harness hits the same gate through the git hook) |
 
 Codex reads `AGENTS.md` natively, so the rules layer works as-is. An existing `.git/hooks/pre-commit` is never overwritten — you get a warning instead.
+
+**Verified (2026-08)**: Codex (codex-cli 0.149.0) auto-loads the `codex`-mode AGENTS.md, answered the rule tiers correctly, and **refused an instruction to commit a `.env` citing the P0 rule** (first line of defense). If a model does try anyway, the git hook blocks it with exit 2 (second line, test-covered). Antigravity (agy 1.1.17) documents `AGENTS.md`/`.agents/rules/` support, but **headless (`-p`) mode measurably does not load rules** — interactive mode is unverified, so Antigravity support is not guaranteed.
 
 ## Language (`--lang`)
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -5,9 +5,10 @@
 [![tests](https://github.com/leeyudok/agents-scaffold/actions/workflows/test.yml/badge.svg)](https://github.com/leeyudok/agents-scaffold/actions/workflows/test.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
-**フレームワークではありません — Claude Code のためのミニマルな fork-and-fill ブートストラップです**。
+**フレームワークではありません — AI コーディングエージェントのためのミニマルな fork-and-fill ブートストラップです**。
 ルール階層を**強制**します: P0(即時停止) / P1(PRブロック) / P2(レビュー指摘)。スタックプリセットは
-単一の pre-commit ゲートに合成されます。
+単一の pre-commit ゲートに合成されます。Claude Code を第一に、Codex など AGENTS.md
+ハーネスは [`--harness`](#ハーネス---harness) で対応します。
 
 ![デモ: ワンコマンドのブートストラップ、生成された .claude/ ツリー、ステージングされた .env をブロックする pre-commit ゲート](docs/assets/demo.gif)
 
@@ -167,6 +168,8 @@ tests/                    ブートストラップスクリプト用 bats リグ
 | `all` | 混在チーム | フルインストール + git フック（Claude Code は PreToolUse、他ハーネスは git フック経由で同じゲートを通る） |
 
 Codex は `AGENTS.md` をネイティブに読むため、ルール層はそのまま機能します。既存の `.git/hooks/pre-commit` は上書きせず、警告のみ出します。
+
+**実測検証（2026-08）**：Codex（codex-cli 0.149.0）は `codex` モード成果物の AGENTS.md を自動で読み込み、ルール階層を正しく回答し、`.env` をコミットせよという指示を **P0 ルールを根拠に自ら拒否**しました（第一の防衛線）。モデルが強行しても git フックが exit 2 でブロックします（第二の防衛線、テスト済み）。Antigravity（agy 1.1.17）はドキュメント上 `AGENTS.md`/`.agents/rules/` をサポートすると記載していますが、**headless（`-p`）モードではルールを読み込まないことを実測** — インタラクティブモードは未検証のため、Antigravity 対応は保証しません。
 
 ## 言語 (`--lang`)
 

--- a/README.md
+++ b/README.md
@@ -5,9 +5,10 @@
 [![tests](https://github.com/leeyudok/agents-scaffold/actions/workflows/test.yml/badge.svg)](https://github.com/leeyudok/agents-scaffold/actions/workflows/test.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
-**프레임워크가 아니라 fork-and-fill 미니멀 부트스트랩** — Claude Code 용 `.claude/` 초기
+**프레임워크가 아니라 fork-and-fill 미니멀 부트스트랩** — AI 코딩 에이전트용 `.claude/` 초기
 구성에 **강제되는** 규칙 티어 P0(즉시 중단)/P1(PR 차단)/P2(리뷰 지적)를 얹고, 스택
-프리셋을 pre-commit 게이트 하나로 합성한다.
+프리셋을 pre-commit 게이트 하나로 합성한다. Claude Code 우선이며, Codex 등 AGENTS.md
+하네스는 [`--harness`](#하네스---harness) 로 지원한다.
 
 ![데모: 원커맨드 부트스트랩 → 생성된 .claude/ 트리 → pre-commit 게이트가 .env 커밋을 차단](docs/assets/demo.gif)
 
@@ -160,6 +161,8 @@ bin/                    agents-scaffold.sh 부트스트랩 스크립트
 | `all` | 혼용 팀 | 전체 설치 + git hook 배선 (Claude Code 는 PreToolUse, 그 외 하네스는 git hook 으로 같은 게이트를 탄다) |
 
 Codex 는 `AGENTS.md` 를 네이티브로 읽으므로 규칙 계층은 그대로 동작한다. 기존 `.git/hooks/pre-commit` 이 있으면 덮어쓰지 않고 경고만 낸다.
+
+**실측 검증 (2026-08)**: Codex(codex-cli 0.149.0)는 `codex` 모드 산출물의 AGENTS.md 를 자동 로드해 룰 티어를 정확히 답했고, `.env` 커밋 지시를 **P0 규칙을 근거로 스스로 거부**했다(1차 방어). 모델이 시도하더라도 git hook 이 exit 2 로 차단한다(2차 방어, 테스트 커버). Antigravity(agy 1.1.17)는 내장 문서상 `AGENTS.md`/`.agents/rules/` 를 지원하나 **headless(`-p`) 모드에서 규칙 미로드가 실측**됐다 — 인터랙티브 모드는 미검증이므로 지원을 보장하지 않는다.
 
 ## 언어 (`--lang`)
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -5,9 +5,10 @@
 [![tests](https://github.com/leeyudok/agents-scaffold/actions/workflows/test.yml/badge.svg)](https://github.com/leeyudok/agents-scaffold/actions/workflows/test.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
-**这不是一个框架，而是一套极简的、fork 后按需填充的 Claude Code 引导脚手架**，
+**这不是一个框架，而是一套极简的、fork 后按需填充的 AI 编码代理引导脚手架**，
 自带**强制执行**的规则分级：P0（立即中止）/ P1（阻断 PR）/ P2（评审提示）。各技术栈预设
-会组合进单一的 pre-commit 门禁。
+会组合进单一的 pre-commit 门禁。以 Claude Code 为先，Codex 等 AGENTS.md harness
+通过 [`--harness`](#harness--harness) 支持。
 
 ![演示：一条命令完成引导、生成的 .claude/ 目录树，以及 pre-commit 门禁拦截暂存的 .env](docs/assets/demo.gif)
 
@@ -165,6 +166,8 @@ tests/                    引导脚本的 bats 回归测试套件
 | `all` | 混合团队 | 完整安装 + git 钩子（Claude Code 走 PreToolUse，其余 harness 通过 git 钩子经过同一道门禁） |
 
 Codex 原生读取 `AGENTS.md`，规则层可直接生效。已存在的 `.git/hooks/pre-commit` 不会被覆盖，只会给出警告。
+
+**实测验证（2026-08）**：Codex（codex-cli 0.149.0）会自动加载 `codex` 模式产物中的 AGENTS.md，正确回答了规则分级，并**依据 P0 规则主动拒绝了提交 `.env` 的指令**（第一道防线）。即使模型执意尝试，git 钩子也会以 exit 2 拦截（第二道防线，已有测试覆盖）。Antigravity（agy 1.1.17）虽在文档中声明支持 `AGENTS.md`/`.agents/rules/`，但**实测其 headless（`-p`）模式不加载规则** — 交互模式未验证，因此不保证对 Antigravity 的支持。
 
 ## 语言（`--lang`）
 


### PR DESCRIPTION
Documentation refresh after real-harness testing:

- **Harness section (x4 languages)**: Codex (codex-cli 0.149.0) verified — auto-loads the codex-mode AGENTS.md, answered the rule tiers, and refused a `.env` commit citing the P0 rule; the git hook remains the second line of defense (test-covered). Antigravity (agy 1.1.17): its embedded docs claim `AGENTS.md`/`.agents/rules/` support, but headless `-p` mode measurably does not load rules; interactive mode unverified — so support is documented as not guaranteed.
- **Intro (x4)**: now reads 'bootstrap for AI coding agents', Claude Code first, with a `--harness` pointer — matches the post-rename scope.