### PR TITLE
chore(#24): 이슈 #20 교차리뷰 결과를 프로젝트 메모리에 기록

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -7,3 +7,6 @@
 ## 프로젝트
 - [제목](project_xxx.md) — 한 줄 훅
 -->
+
+- [하네스 설정 계약 실측](reference_harness-config-contracts.md) — Claude/Codex/agy 의 설정·디스커버리 경로와 함정(32KiB, trust boundary, PreToolUse 는 강제선 아님)
+- [이슈 #20 3자 교차리뷰 결론](project_agents-scaffold-multiagent-review.md) — compile-time emitter 확정, 해시검증 폐기→P0 reachability, 남은 후속 a~c

--- a/.claude/memory/project_agents-scaffold-multiagent-review.md
+++ b/.claude/memory/project_agents-scaffold-multiagent-review.md
@@ -1,0 +1,20 @@
+---
+name: project_agents-scaffold-multiagent-review
+description: 이슈 #20 3자 AI 교차리뷰로 확정된 설계 결론과 남은 후속 작업 (2026-08-22)
+metadata:
+  type: project
+---
+
+2026-08-22 이슈 #20 에서 Claude·GPT(Codex)·Antigravity 세 에이전트가 교차리뷰해 확정한 아키텍처 결론. #20·#21 은 CLOSED, #21(core hardening)은 PR #23 으로 머지됨.
+
+**확정 결론**: 중립 semantic core 유지 + 설치 시 선택한 하네스에 대해 검증된 native discovery/metadata 만 **정적 생성**(compile-time target emitter). 정책 본문을 범용 IR 로 의미 변환하지 않고, 미지원 capability 는 emulation 하지 않고 강등. 강제선은 하네스 밖(CI·git hook·sandbox).
+
+**Why**: 완전 범용은 최소공약수(강제력 상실), 하네스별 완전 복제는 drift·죽은 어댑터. 논쟁 중 "정책 본문 바이트 동일 해시 검증"안이 나왔다가 **폐기** — 같은 바이트가 하네스별로 조건부/전량/미로드로 갈리는데 해시는 전부 통과하므로 틀린 것을 측정한다. 대체안이 **P0 reachability 검사**(각 하네스에서 P0 문장이 상시/조건부/미도달 중 어디에 있는지 정적 산출, 미도달 P0 있으면 실패).
+
+**How to apply**: 남은 후속 작업 —
+- a-1 지원 매트릭스 machine-readable manifest (하네스 × CLI버전 × capability × 로딩시점 × 바이트예산 × 실측일자 × trust상태). **어댑터 만료 규칙은 manifest 가 생긴 뒤에 켠다** — 지금 T2 인프라가 0이라 먼저 켜면 한 분기 뒤 전 어댑터 unsupported + 코드 잔존
+- a-2 Codex spike / a-3 agy spike(1.1.17 headless 미로드 **원인 규명**) / a-4 enforcement coverage 표
+- c 골든 스냅샷 테스트 — 현재 bats 에 `diff -r`/snapshot/해시 비교가 **0건**이라 "산출물 무변경 리팩터"를 검증할 수단이 없다. 리팩터 전 선행 필수
+- emitter 산출물에 `harness/CLI버전/생성일자/capability등급` provenance 기록 (배포된 사용자 레포는 회수 불가하므로 최소한 `--update` 가 강등을 알려야 함)
+
+하네스별 경로·계약 사실은 [[reference_harness-config-contracts]].

--- a/.claude/memory/reference_harness-config-contracts.md
+++ b/.claude/memory/reference_harness-config-contracts.md
@@ -1,0 +1,32 @@
+---
+name: reference_harness-config-contracts
+description: Claude Code / Codex / agy 세 하네스의 설정·디스커버리 계약 실측 결과와 공식문서 위치 (2026-08-22)
+metadata:
+  type: reference
+---
+
+이슈 #20 논쟁 중 3자(Claude·GPT/Codex·Antigravity)가 공식문서와 로컬 CLI 로 실측한 계약. 버전이 회전하므로 재사용 전 `--version` 대조할 것.
+
+실측 버전: `claude 2.1.239` / `codex-cli 0.149.0` / `agy 1.1.18` (2026-08-22, 맥 로컬)
+
+## Claude Code
+- 프로젝트 설정 = `.claude/settings.json` (`.claude.json` 은 유저 전역 상태 파일이지 프로젝트 설정 아님)
+- **`.claude/rules/*.md` + `paths:` frontmatter 조건부 로딩은 네이티브 기능** — [memory.md § Organize rules with .claude/rules/](https://code.claude.com/docs/en/memory.md#organize-rules-with-claude/rules/). `paths:` 없으면 세션 시작 시 상시 로드
+- `@경로` import 최대 4 레벨. **AGENTS.md 는 네이티브로 안 읽음** — `CLAUDE.md` 의 `@AGENTS.md` import 에 의존
+- `.claude/commands/` 는 레거시(skills 로 통합), `.claude/workflows/`·`.claude/scripts/` 는 **자동 로드 안 됨**
+- `settings.json` 의 `PreToolUse` 훅은 그 세션이 Bash 툴로 커밋할 때만 발동 → **강제선 아님**(조기 피드백). 결정적 강제는 `.git/hooks` + CI
+
+## Codex
+- instructions = `AGENTS.md` + nested `AGENTS.override.md` 계층, **합산 기본 한도 32KiB** (`project_doc_max_bytes`)
+- repo skills = `.agents/skills/*/SKILL.md` (CWD→repo root 스캔). `.claude/skills` 는 발견 경로 아님
+- 프로젝트 설정 = `.codex/config.toml`, hooks = `.codex/hooks.json`, subagents = `.codex/agents/*.toml`
+- **trust boundary**: `.codex/` 레이어는 프로젝트를 신뢰한 경우에만 로드 → "파일 생성 = 활성화"가 아님
+- hook 은 정의 **hash 에 신뢰가 묶임** → 정의 변경 시 재승인 전까지 skip
+- `.codex/rules/*.rules` 는 **명령 실행 정책**(prefix_rule allow/prompt/forbidden)이지 Claude 의 `paths:` 코딩 가이던스와 다름. experimental
+- 공통 `--instructions` 플래그 없음
+
+## agy (Antigravity)
+- 공통 `--instructions` 플래그 없음 (`--agent`, `--mode`, `plugin` 등)
+- 1.1.17 headless(`-p`) 에서 규칙 미로드 실측 — 원인 미규명. interactive 미검증
+
+관련: [[project_agents-scaffold-multiagent-review]]


### PR DESCRIPTION
이슈 #20 의 3자 AI 교차리뷰에서 확정된 설계 결론과, 그 과정에서 실측된 세 하네스의 설정·디스커버리 계약을 `.claude/memory/` 에 기록한다.

## 추가

- `reference_harness-config-contracts.md` — 2026-08-22 실측(claude 2.1.239 / codex-cli 0.149.0 / agy 1.1.18). Codex 32KiB instruction 한도, `.codex/` trust boundary, Claude `PreToolUse` 가 강제선이 아닌 이유, `.claude/rules/` + `paths:` 공식문서 위치
- `project_agents-scaffold-multiagent-review.md` — compile-time target emitter 확정, 바이트 해시 검증 폐기 → P0 reachability, 남은 후속 a-1~c
- `MEMORY.md` 인덱스 2줄

문서만 변경하며 코드·테스트 영향 없음.

Closes #24