### PR TITLE
docs(#26): README 4종 현행화 — 하네스 계약 실측 반영, 자동로드 오해 정정

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -89,7 +89,7 @@ result is plain files under version control like any other code in the repo.
     sdlc-tester.md        AC/TC test-writing agent
     sdlc-verifier.md      pipeline execution + report agent
     agent-evolve.md       self-improving meta agent — refines agents/*.md from run feedback
-  commands/
+  commands/              (legacy on Claude Code — slash commands merged into skills)
     sonar.md             SonarQube analysis (CE task polling, sqp_/squ_ token handling)
     sdlc-cycle.md         5-stage SDLC automation
     knowledge-graph.md    regenerate the .claude knowledge graph + broken-link check
@@ -114,18 +114,18 @@ result is plain files under version control like any other code in the repo.
     review/                   code-reviewer + security-audit wrapper
     memory-factcheck/         memory fact-check — verify claims against code/DB/issues, correct stale
     security-precheck/        pre-audit security sweep → issues → parallel fixes
-  workflows/
+  workflows/             (not auto-loaded — invoked explicitly)
     rules-audit.js           stored Workflow example — scan/verify/repair with human merge gate
-  scripts/
+  scripts/               (not auto-loaded — invoked explicitly)
     knowledge_graph.py       .claude ecosystem graph + --check broken-link gate
   settings.json               hook wiring + default deny rules
 AGENTS.md                 project brain — rule SSOT (P0/P1/P2 + workflow)
-CLAUDE.md                 pointer to @AGENTS.md (Claude Code)
-GEMINI.md                 pointer to @AGENTS.md (Gemini CLI)
+CLAUDE.md                 @AGENTS.md + memory-index import (Claude Code)
+GEMINI.md                 @AGENTS.md + memory-index import (Gemini CLI)
 presets/                  preset fragments (copy-overwrite model)
   forge-github/           GitHub forge — gh, PRs, `Closes #N` auto-close
   forge-gitlab/           GitLab forge — glab, MRs, `Closes #N` auto-close (verify after merge)
-  nextjs/ bun/ ...        per-stack fragments (rules + pre-commit.partial.sh)
+  nextjs/ bun/ ...        per-stack fragments (rules + pre-commit.partial.sh + AGENTS.partial.md)
   lang-en/                English overlay (base/forge-*/stacks/*) — see `--lang` below
 bin/                      agents-scaffold.sh bootstrap script
 tests/                    bats regression suite for the bootstrap script
@@ -178,7 +178,29 @@ The git hook is **always wired, regardless of harness** (#21). Claude Code's `Pr
 
 The selected stack's P0 rules are **inlined into the `AGENTS.md` body**, so they do not depend on a `.claude/rules/` reference link and stay reachable on harnesses that never load `.claude/`. Stacks you did not select are not inlined (Codex caps combined instructions at 32KiB by default — this avoids context flooding).
 
-**Verified (2026-08)**: Codex (codex-cli 0.149.0) auto-loads the `codex`-mode AGENTS.md, answered the rule tiers correctly, and **refused an instruction to commit a `.env` citing the P0 rule** (first line of defense). If a model does try anyway, the git hook blocks it with exit 2 (second line, test-covered). Antigravity (agy 1.1.17) documents `AGENTS.md`/`.agents/rules/` support, but **headless (`-p`) mode measurably does not load rules** — interactive mode is unverified, so Antigravity support is not guaranteed.
+### Verified (2026-08-22)
+
+| Harness | Measured version | baseline | What is / isn't confirmed on the full tier |
+|---|---|---|---|
+| Claude Code | 2.1.239 | holds | `paths:`-scoped loading of `.claude/rules/*.md`, subagents, skills, `settings.json` hooks — all confirmed against the [official docs](https://code.claude.com/docs/en/memory.md) |
+| Codex | codex-cli 0.149.0 | holds | `AGENTS.md` auto-load and a P0-cited `.env` refusal were measured. **Skills are not discovered** (see below) |
+| Antigravity | agy **1.1.18** (not re-measured) | holds | On 1.1.17, **headless (`-p`) measurably did not load rules** — root cause unknown. Neither 1.1.18 nor interactive mode has been re-measured |
+
+Codex (codex-cli 0.149.0) auto-loads the `codex`-mode AGENTS.md, answered the rule tiers
+correctly, and **refused an instruction to commit a `.env`, citing the P0 rule** (first line of
+defense). If a model tries anyway, the git hook blocks it with exit 2 (second line, test-covered).
+
+**Known gap — Codex skills are not auto-discovered.** Codex discovers repository skills under
+`.agents/skills`, but `--harness codex` currently leaves them in `.claude/skills`. The rules layer
+(`AGENTS.md`) works; the skills layer does not — that is baseline, not full.
+
+Two further Codex constraints shape the design:
+
+- **Combined instructions are capped at 32KiB by default** (`project_doc_max_bytes`), which is why
+  only the selected stack's P0 is inlined into `AGENTS.md` (measured 6,869 B with `--stack javaweb`
+  — 21% of the cap).
+- **The `.codex/` layer only loads for a trusted project.** Emitting a file does not guarantee it is
+  active, which is why the deterministic enforcement line lives in `.git/hooks` + CI.
 
 ## Language (`--lang`)
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -89,7 +89,7 @@ agents-scaffold/bin/agents-scaffold.sh /path/to/new-repo --forge github --stack 
     sdlc-tester.md        AC/TC テスト作成エージェント
     sdlc-verifier.md      パイプライン実行 + レポートエージェント
     agent-evolve.md       自己改善メタエージェント — 実行フィードバックから agents/*.md を洗練
-  commands/
+  commands/              （Claude Code ではレガシー — スラッシュコマンドは skills に統合）
     sonar.md             SonarQube 分析(CE タスクポーリング、sqp_/squ_ トークン処理)
     sdlc-cycle.md         5段階 SDLC 自動化
     knowledge-graph.md    .claude ナレッジグラフ再生成 + リンク切れチェック
@@ -114,18 +114,18 @@ agents-scaffold/bin/agents-scaffold.sh /path/to/new-repo --forge github --stack 
     review/                   code-reviewer + security-audit ラッパー
     memory-factcheck/         メモリのファクトチェック — 主張をコード/DB/イシューと照合し、古いものを修正
     security-precheck/        監査前セキュリティスイープ → イシュー化 → 並列修正
-  workflows/
+  workflows/             （自動ロードされない — 明示的に呼び出す）
     rules-audit.js           保存型 Workflow の例 — scan/verify/repair、マージは人間ゲート
-  scripts/
+  scripts/               （自動ロードされない — 明示的に呼び出す）
     knowledge_graph.py       .claude エコシステムグラフ + --check リンク切れゲート
   settings.json               フック配線 + デフォルト deny ルール
 AGENTS.md                 プロジェクトの頭脳 — ルール SSOT(P0/P1/P2 + ワークフロー)
-CLAUDE.md                 @AGENTS.md へのポインタ(Claude Code)
-GEMINI.md                 @AGENTS.md へのポインタ(Gemini CLI)
+CLAUDE.md                 @AGENTS.md + メモリインデックスの import (Claude Code)
+GEMINI.md                 @AGENTS.md + メモリインデックスの import (Gemini CLI)
 presets/                  プリセット断片(コピー上書きモデル)
   forge-github/           GitHub forge — gh、PR、`Closes #N` 自動クローズ
   forge-gitlab/           GitLab forge — glab、MR、`Closes #N` 自動クローズ(マージ後に確認)
-  nextjs/ bun/ ...        スタック別断片(rules + pre-commit.partial.sh)
+  nextjs/ bun/ ...        スタック別断片(rules + pre-commit.partial.sh + AGENTS.partial.md)
   lang-en/                英語オーバーレイ(base/forge-*/stacks/*)— 後述の `--lang` を参照
 bin/                      agents-scaffold.sh ブートストラップスクリプト
 tests/                    ブートストラップスクリプト用 bats リグレッションスイート
@@ -178,7 +178,22 @@ git フックは**ハーネスに関係なく常に配線されます**（#21）
 
 選択したスタックの P0 は **`AGENTS.md` 本文に直接挿入**されます。`.claude/rules/` の参照リンクに依存しないため、`.claude/` を読み込まないハーネスでも到達可能です。選択していないスタックは挿入されません（Codex の指示合計はデフォルト 32KiB 上限 — context flooding を防ぐため）。
 
-**実測検証（2026-08）**：Codex（codex-cli 0.149.0）は `codex` モード成果物の AGENTS.md を自動で読み込み、ルール階層を正しく回答し、`.env` をコミットせよという指示を **P0 ルールを根拠に自ら拒否**しました（第一の防衛線）。モデルが強行しても git フックが exit 2 でブロックします（第二の防衛線、テスト済み）。Antigravity（agy 1.1.17）はドキュメント上 `AGENTS.md`/`.agents/rules/` をサポートすると記載していますが、**headless（`-p`）モードではルールを読み込まないことを実測** — インタラクティブモードは未検証のため、Antigravity 対応は保証しません。
+### 実測検証（2026-08-22）
+
+| ハーネス | 実測バージョン | baseline | full 層で確認できたこと / できていないこと |
+|---|---|---|---|
+| Claude Code | 2.1.239 | 成立 | `.claude/rules/*.md` の `paths:` 条件付きロード、サブエージェント、skills、`settings.json` フック — いずれも[公式ドキュメント](https://code.claude.com/docs/en/memory.md)で確認 |
+| Codex | codex-cli 0.149.0 | 成立 | `AGENTS.md` の自動ロードと P0 を根拠にした `.env` 拒否を実測。**skills は発見されない**（下記） |
+| Antigravity | agy **1.1.18**（再測定なし） | 成立 | 1.1.17 で **headless（`-p`）がルールを読み込まない**ことを実測 — 原因は未解明。1.1.18 もインタラクティブモードも未検証 |
+
+Codex（codex-cli 0.149.0）は `codex` モード成果物の AGENTS.md を自動で読み込み、ルール階層を正しく回答し、`.env` をコミットせよという指示を **P0 ルールを根拠に自ら拒否**しました（第一の防衛線）。モデルが強行しても git フックが exit 2 でブロックします（第二の防衛線、テスト済み）。
+
+**既知のギャップ — Codex の skills は自動発見されません。** Codex がリポジトリの skills を探す場所は `.agents/skills` ですが、現在の `--harness codex` は `.claude/skills` に残します。ルール層（`AGENTS.md`）は機能しますが skills 層は機能しません — これは full ではなく baseline です。
+
+Codex 側の制約がもう 2 点、設計に効いてきます。
+
+- **指示の合計はデフォルト 32KiB 上限**（`project_doc_max_bytes`）。そのため選択したスタックの P0 のみを `AGENTS.md` にインライン化します（`--stack javaweb` で実測 6,869 B — 上限の 21%）。
+- **`.codex/` レイヤは信頼済みプロジェクトでのみロードされます。** ファイルを生成しても有効化は保証されません。だからこそ決定的な強制線は `.git/hooks` + CI に置きます。
 
 ## 言語 (`--lang`)
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ placeholder 를 채우고 안 쓰는 걸 지우면, 결과는 레포의 다른 �
     sdlc-tester.md      AC/TC 테스트 작성 에이전트
     sdlc-verifier.md    파이프라인 실행·리포트 에이전트
     agent-evolve.md     자기개선 메타 에이전트 — 실행 피드백으로 agents/*.md 자동 개선
-  commands/
+  commands/            (Claude Code 에서는 레거시 — 슬래시 커맨드가 skills 로 통합됨)
     sonar.md            SonarQube 분석 (CE task 폴링, sqp_/squ_ 구분)
     sdlc-cycle.md       5단계 SDLC 자동화
     knowledge-graph.md  .claude 지식 그래프 재생성 + 깨진 링크 체크
@@ -110,18 +110,18 @@ placeholder 를 채우고 안 쓰는 걸 지우면, 결과는 레포의 다른 �
     review/             code-reviewer + security-audit 래퍼
     memory-factcheck/   메모리 사실 검증 — 코드·DB·이슈 대조로 stale 정정
     security-precheck/  감사 대비 보안 사전점검 → 이슈 → 병렬 수정
-  workflows/
+  workflows/            (자동 로드 아님 — 명시 호출로만 실행)
     rules-audit.js      저장형 Workflow 예제 — 스캔/검증/수정, 머지는 사람 게이트
-  scripts/
+  scripts/              (자동 로드 아님 — 명시 호출로만 실행)
     knowledge_graph.py  .claude 생태계 그래프 + --check 깨진 링크 게이트
   settings.json         hooks 와이어링 + deny 기본값
 AGENTS.md               프로젝트 브레인 — 규칙 SSOT (P0/P1/P2 + 워크플로)
-CLAUDE.md               @AGENTS.md 포인터 (Claude Code)
-GEMINI.md               @AGENTS.md 포인터 (Gemini CLI)
+CLAUDE.md               @AGENTS.md + 메모리 인덱스 import (Claude Code)
+GEMINI.md               @AGENTS.md + 메모리 인덱스 import (Gemini CLI)
 presets/                프리셋 조각 (복사 덮어쓰기 방식)
   forge-github/         GitHub forge — gh, PR, `Closes #N` 자동 클로즈
   forge-gitlab/         GitLab forge — glab, MR, `Closes #N` 자동 클로즈(머지 후 확인)
-  nextjs/ bun/ ...      스택별 조각 (rules + pre-commit.partial.sh)
+  nextjs/ bun/ ...      스택별 조각 (rules + pre-commit.partial.sh + AGENTS.partial.md)
   lang-en/              영어 오버레이 (base/forge-*/stacks/*) — 아래 `--lang` 참조
 bin/                    agents-scaffold.sh 부트스트랩 스크립트
 ```
@@ -175,7 +175,28 @@ Bash 툴로 커밋할 때만 발동하므로 조기 피드백 계층이지 강�
 않으므로 `.claude/` 를 로드하지 않는 하네스에서도 도달 가능하다. 선택하지 않은 스택은 삽입되지
 않는다(Codex instruction 합산 기본 한도 32KiB — context flooding 방지).
 
-**실측 검증 (2026-08)**: Codex(codex-cli 0.149.0)는 `codex` 모드 산출물의 AGENTS.md 를 자동 로드해 룰 티어를 정확히 답했고, `.env` 커밋 지시를 **P0 규칙을 근거로 스스로 거부**했다(1차 방어). 모델이 시도하더라도 git hook 이 exit 2 로 차단한다(2차 방어, 테스트 커버). Antigravity(agy 1.1.17)는 내장 문서상 `AGENTS.md`/`.agents/rules/` 를 지원하나 **headless(`-p`) 모드에서 규칙 미로드가 실측**됐다 — 인터랙티브 모드는 미검증이므로 지원을 보장하지 않는다.
+### 실측 검증 (2026-08-22)
+
+| 하네스 | 실측 버전 | baseline | full 쪽 확인된 것 / 확인 안 된 것 |
+|---|---|---|---|
+| Claude Code | 2.1.239 | 성립 | `.claude/rules/*.md` 의 `paths:` 조건부 로딩, 서브에이전트, skills, `settings.json` 훅 — 전부 [공식 문서](https://code.claude.com/docs/en/memory.md)로 확인 |
+| Codex | codex-cli 0.149.0 | 성립 | `AGENTS.md` 자동 로드·P0 근거 `.env` 거부까지 실측. **스킬은 발견되지 않는다**(아래) |
+| Antigravity | agy **1.1.18** (미재검증) | 성립 | 1.1.17 에서 **headless(`-p`) 규칙 미로드** 실측 — 원인 미규명. 1.1.18 재검증·인터랙티브 모드 모두 미실시 |
+
+Codex(codex-cli 0.149.0)는 `codex` 모드 산출물의 AGENTS.md 를 자동 로드해 룰 티어를 정확히
+답했고, `.env` 커밋 지시를 **P0 규칙을 근거로 스스로 거부**했다(1차 방어). 모델이 시도해도
+git hook 이 exit 2 로 차단한다(2차 방어, 테스트 커버).
+
+**알려진 갭 — Codex 스킬은 자동 발견되지 않는다.** Codex 의 저장소 스킬 발견 경로는
+`.agents/skills` 인데 현재 `--harness codex` 는 `.claude/skills` 를 남긴다. 규칙 계층
+(`AGENTS.md`)은 동작하지만 스킬은 그렇지 않다 — full 이 아니라 baseline 이다.
+
+Codex 쪽 추가 제약 두 가지도 설계에 영향을 준다.
+
+- **instruction 합산 기본 한도 32KiB** (`project_doc_max_bytes`). 그래서 스택 P0 는 선택한
+  스택만 `AGENTS.md` 에 인라인한다 (`--stack javaweb` 기준 실측 6,869 B — 한도의 21%).
+- **`.codex/` 레이어는 프로젝트를 신뢰한 경우에만 로드된다.** 파일을 생성했다고 활성화가
+  보장되지 않는다. 그래서 결정적 강제선을 `.git/hooks` + CI 에 둔다.
 
 ## 언어 (`--lang`)
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -87,7 +87,7 @@ prompt 编写也没关系：
     sdlc-tester.md        AC/TC 测试编写 agent
     sdlc-verifier.md      流水线执行 + 报告 agent
     agent-evolve.md       自我改进元 agent —— 根据运行反馈打磨 agents/*.md
-  commands/
+  commands/              （在 Claude Code 上属遗留 — 斜杠命令已并入 skills）
     sonar.md             SonarQube 分析（CE 任务轮询、sqp_/squ_ 令牌处理）
     sdlc-cycle.md         5 阶段 SDLC 自动化
     knowledge-graph.md    重新生成 .claude 知识图谱 + 断链检查
@@ -112,14 +112,14 @@ prompt 编写也没关系：
     review/                   code-reviewer + security-audit 封装
     memory-factcheck/         记忆事实核查 —— 对照代码/DB/issue 验证并修正过期内容
     security-precheck/        审计前安全排查 → 拆分 issue → 并行修复
-  workflows/
+  workflows/             （不会自动加载 — 需显式调用）
     rules-audit.js           存储式 Workflow 示例 —— 扫描/验证/修复，合并由人工把关
-  scripts/
+  scripts/               （不会自动加载 — 需显式调用）
     knowledge_graph.py       .claude 生态图谱 + --check 断链门禁
   settings.json               钩子接线 + 默认 deny 规则
 AGENTS.md                 项目大脑 —— 规则 SSOT（P0/P1/P2 + 工作流）
-CLAUDE.md                 指向 @AGENTS.md 的指针（Claude Code）
-GEMINI.md                 指向 @AGENTS.md 的指针（Gemini CLI）
+CLAUDE.md                 @AGENTS.md + 记忆索引 import（Claude Code）
+GEMINI.md                 @AGENTS.md + 记忆索引 import（Gemini CLI）
 presets/                  预设片段（复制覆盖模型）
   forge-github/           GitHub forge —— gh、PR、`Closes #N` 自动关闭
   forge-gitlab/           GitLab forge —— glab、MR、`Closes #N` 自动关闭（合并后需确认）
@@ -176,7 +176,22 @@ git 钩子**与 harness 无关，始终接入**（#21）。Claude Code 的 `PreT
 
 所选技术栈的 P0 会**直接插入 `AGENTS.md` 正文**，不依赖 `.claude/rules/` 引用链接，因此在不加载 `.claude/` 的 harness 上同样可达。未选择的技术栈不会被插入（Codex 指令合计默认上限为 32KiB — 以避免 context flooding）。
 
-**实测验证（2026-08）**：Codex（codex-cli 0.149.0）会自动加载 `codex` 模式产物中的 AGENTS.md，正确回答了规则分级，并**依据 P0 规则主动拒绝了提交 `.env` 的指令**（第一道防线）。即使模型执意尝试，git 钩子也会以 exit 2 拦截（第二道防线，已有测试覆盖）。Antigravity（agy 1.1.17）虽在文档中声明支持 `AGENTS.md`/`.agents/rules/`，但**实测其 headless（`-p`）模式不加载规则** — 交互模式未验证，因此不保证对 Antigravity 的支持。
+### 实测验证（2026-08-22）
+
+| Harness | 实测版本 | baseline | full 层已确认 / 未确认的内容 |
+|---|---|---|---|
+| Claude Code | 2.1.239 | 成立 | `.claude/rules/*.md` 的 `paths:` 条件加载、子代理、skills、`settings.json` 钩子 — 均已对照[官方文档](https://code.claude.com/docs/en/memory.md)确认 |
+| Codex | codex-cli 0.149.0 | 成立 | 已实测 `AGENTS.md` 自动加载与依据 P0 拒绝 `.env`。**skills 不会被发现**（见下） |
+| Antigravity | agy **1.1.18**（未重测） | 成立 | 1.1.17 上实测 **headless（`-p`）不加载规则** — 原因未查明。1.1.18 与交互模式均未重测 |
+
+Codex（codex-cli 0.149.0）会自动加载 `codex` 模式产物中的 AGENTS.md，正确回答了规则分级，并**依据 P0 规则主动拒绝了提交 `.env` 的指令**（第一道防线）。即使模型执意尝试，git 钩子也会以 exit 2 拦截（第二道防线，已有测试覆盖）。
+
+**已知缺口 — Codex 的 skills 不会被自动发现。** Codex 发现仓库 skills 的路径是 `.agents/skills`，而当前 `--harness codex` 仍将其留在 `.claude/skills`。规则层（`AGENTS.md`）可用，skills 层不可用 — 这属于 baseline 而非 full。
+
+另有两项 Codex 约束影响设计：
+
+- **指令合计默认上限 32KiB**（`project_doc_max_bytes`），因此只把所选技术栈的 P0 内联进 `AGENTS.md`（`--stack javaweb` 实测 6,869 B — 占上限的 21%）。
+- **`.codex/` 层仅在项目受信任时加载。** 生成文件并不等于生效，因此决定性的强制线放在 `.git/hooks` + CI。
 
 ## 语言（`--lang`）
 


### PR DESCRIPTION
#20 교차리뷰와 #21 구현 이후 README(ko/en/zh/ja)가 실제 동작과 어긋나던 부분을 정정한다.

## 하네스 섹션 → 실측 표로 교체

- Claude Code 2.1.239 / codex-cli 0.149.0 / agy 1.1.18 을 baseline·full 구분과 함께 기재
- **알려진 갭 신설**: Codex 의 저장소 스킬 발견 경로는 `.agents/skills` 인데 `--harness codex` 는 `.claude/skills` 를 남긴다 → 규칙 계층은 동작하지만 스킬은 발견되지 않는다. 기존 문구("규칙 계층은 그대로 동작한다")는 스킬까지 되는 것처럼 읽혔다
- agy 는 1.1.17 에서 headless 미로드가 관측됐고 **1.1.18 재검증·인터랙티브 모드 모두 미실시**임을 명시
- Codex instruction 32KiB 한도와 `.codex/` trust boundary 를 설계 근거로 기재

## 트리 설명 정정

- `.claude/workflows/`, `.claude/scripts/` → "자동 로드 아님 — 명시 호출"
- `.claude/commands/` → 레거시 표기(슬래시 커맨드는 skills 로 통합)
- 스택 프리셋에 `AGENTS.partial.md` 추가(#21 산출물)
- CLAUDE.md/GEMINI.md → "@AGENTS.md + 메모리 인덱스 import"

문서만 변경. bats 37/37, 링크 체커 0 broken.

Closes #26