### PR TITLE
chore: README 다국어 동시 수정 규칙을 메모리에 기록

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -10,3 +10,4 @@
 
 - [하네스 설정 계약 실측](reference_harness-config-contracts.md) — Claude/Codex/agy 의 설정·디스커버리 경로와 함정(32KiB, trust boundary, PreToolUse 는 강제선 아님)
 - [이슈 #20 3자 교차리뷰 결론](project_agents-scaffold-multiagent-review.md) — compile-time emitter 확정, 해시검증 폐기→P0 reachability, 남은 후속 a~c
+- [README 다국어 동시 수정](feedback_readme-multilang-sync.md) — README.md 고치면 en/zh/ja 3종도 같은 커밋에서. 언어 간 일치를 검사하는 자동 게이트가 없다

--- a/.claude/memory/feedback_readme-multilang-sync.md
+++ b/.claude/memory/feedback_readme-multilang-sync.md
@@ -1,0 +1,18 @@
+---
+name: feedback_readme-multilang-sync
+description: README.md 를 고치면 README.en/zh/ja 3종도 같은 커밋에서 함께 고친다
+metadata:
+  type: feedback
+---
+
+`README.md`(한국어)를 수정할 때는 **`README.en.md` · `README.zh.md` · `README.ja.md` 3종을 같은 커밋에서 함께 수정한다.** 한국어만 고치고 나머지를 미루지 않는다 (2026-08-22 지시).
+
+**Why**: 이 저장소의 README 는 4개 언어가 같은 내용을 담는 병렬 문서다. 한쪽만 갱신하면 나머지 3개가 조용히 stale 이 되는데, 링크 체커(`knowledge_graph.py --check`)도 bats 스위트도 **언어 간 내용 일치는 검사하지 않으므로** 어떤 자동 게이트에도 걸리지 않는다. 실제로 #26 에서 하네스 실측 서술·트리 설명이 4종 모두에서 동시에 낡아 있었다.
+
+**How to apply**:
+- README 변경 diff 를 만들 때 대상 파일 목록을 항상 `README.md README.en.md README.zh.md README.ja.md` 로 잡는다.
+- 번역이 아니라 **같은 사실의 각 언어판**이다 — 수치·버전·경로·표 구조를 동일하게 유지하고, 문장만 해당 언어답게 쓴다.
+- 언어별로 대응 문자열이 달라 치환이 깨지기 쉬우므로, 4개 파일 각각에서 교체 대상 원문을 먼저 `grep -n` 으로 확인한 뒤 수정한다.
+- 같은 원칙이 `presets/lang-en/` 오버레이에도 적용된다 — ko 베이스 파일을 고쳤으면 대응하는 `presets/lang-en/` 파일도 같은 커밋에서 고친다 (#21 의 `AGENTS.partial.md` 10 + 10 이 그 예).
+
+관련: [[project_agents-scaffold-multiagent-review]]


### PR DESCRIPTION
`README.md` 를 고치면 `README.en.md`·`README.zh.md`·`README.ja.md` 3종도 같은 커밋에서 함께 고친다는 규칙을 `.claude/memory/feedback_readme-multilang-sync.md` 로 기록한다.

링크 체커(`knowledge_graph.py --check`)도 bats 스위트도 **언어 간 내용 일치는 검사하지 않는다** — 한국어만 갱신하면 나머지 3종이 어떤 자동 게이트에도 걸리지 않고 stale 이 된다. #26 에서 실제로 4종이 동시에 낡아 있었다.

같은 원칙이 `presets/lang-en/` 오버레이에도 적용된다.

메모리 파일만 추가. 코드·테스트 영향 없음.