### PR TITLE
docs(#33): README 를 랜딩/레퍼런스 2층으로 분리 — 315줄 → 112줄

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -5,14 +5,23 @@
 [![tests](https://github.com/leeyudok/agents-scaffold/actions/workflows/test.yml/badge.svg)](https://github.com/leeyudok/agents-scaffold/actions/workflows/test.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
-**Not a framework — a minimal, fork-and-fill bootstrap for AI coding agents** with
-**enforced** rule tiers: P0 (halt) / P1 (PR-block) / P2 (review). Stack presets
-compose into a single pre-commit gate. Claude Code first; Codex and other
-AGENTS.md harnesses are supported via [`--harness`](#harness---harness).
+**AI coding agents break your rules. This blocks the commit instead of asking nicely.**
+
+One command drops a `.claude/` setup and a pre-commit gate into your repo. No framework, no
+runtime, no registry to install from — what you get is **plain files you own outright.**
 
 ![Demo: one-command bootstrap, the generated .claude/ tree, and the pre-commit gate blocking a staged .env](docs/assets/demo.gif)
 
 _30-second demo: one command → a filled `.claude/` → the gate blocks a secret commit. Reproduce with `vhs docs/assets/demo.tape`._
+
+## You want this if
+
+- You **re-explain the same rules every session** — what you told the agent yesterday is gone today.
+- An agent staged your `.env`, or produced a commit with type errors still in it.
+- Every teammate has a different `CLAUDE.md`, so **results depend on whose session it was.**
+
+Rules that live only in a document get ignored eventually. This scaffold turns them into a
+**gate that blocks the commit**, and plants it in the repo.
 
 ## Quickstart
 
@@ -27,7 +36,21 @@ agents-scaffold/bin/agents-scaffold.sh /path/to/new-repo --forge github --stack 
 
 You get a filled-in `.claude/` directory (agents, skills, hooks, paths-scoped
 rules, memory), an `AGENTS.md` project brain, and a single composed pre-commit
-gate — plain files you own outright. Full options: see [Usage](#usage-1--script).
+gate — plain files you own outright. Full options: see [Usage](docs/OPTIONS.en.md#usage-1--script).
+
+## What happens the moment it's installed
+
+When an agent — or a person — tries to commit a secret, **the commit does not happen.**
+
+```console
+$ bash agents-scaffold.sh . --stack python --name payments --yes
+$ echo 'DB_PASSWORD=hunter2' > .env
+$ git add -f .env app.py && git commit -m "feat: add config"
+Blocked: a .env-type file is staged. Commit is not allowed.
+```
+
+This is not the same as writing "don't commit secrets" in a doc. `.git/hooks/pre-commit` is what
+stops it, so **it holds whichever AI tool you use, and it holds when a human commits by hand.**
 
 ## What you get — for beginners
 
@@ -50,7 +73,7 @@ you're new to prompting:
   `/knowledge-graph` (doc link checker), `/sonar`.
 - **Requirements hardening, your pick of three**: beyond the bundled **`grill-me`**, two
   external tools plug in depending on the job →
-  [Picking a requirements-hardening tool](#picking-a-requirements-hardening-tool).
+  [Picking a requirements-hardening tool](docs/OPTIONS.en.md#picking-a-requirements-hardening-tool).
 - **Memory that survives sessions**: project learnings accumulate under
   `.claude/memory/`, auto-load next session, and are shared with the team.
 - **Self-evolving**: skill-evolve/agent-evolve rewrite skill/agent definitions from
@@ -76,251 +99,13 @@ result is plain files under version control like any other code in the repo.
 - **Tested** — the bootstrap script ships with a bats regression suite, and a
   knowledge-graph link checker gates the docs.
 
-## What's inside
+## Going further
 
-```
-.claude/
-  agents/
-    security-audit.md   12-item P0/P1 security grep scan
-    db-migration.md      DDL safety check + rollback SQL generation
-    sdlc-developer.md    minimal-scope implementation agent (SDLC role split)
-    sdlc-tester.md        AC/TC test-writing agent
-    sdlc-verifier.md      pipeline execution + report agent
-    agent-evolve.md       self-improving meta agent — refines agents/*.md from run feedback
-  commands/              (legacy on Claude Code — slash commands merged into skills)
-    sonar.md             SonarQube analysis (CE task polling, sqp_/squ_ token handling)
-    sdlc-cycle.md         5-stage SDLC automation
-    knowledge-graph.md    regenerate the .claude knowledge graph + broken-link check
-  hooks/
-    pre-commit.sh         pre-commit gate skeleton (stack partial entry point)
-    post-edit-format.sh   PostToolUse(Edit|Write) → auto-format
-    post-test-notify.sh   PostToolUse(Bash, *test*) → terminal notification
-    stop-memory-remind.sh Stop hook → once-per-session memory reminder
-    cc-check.py            PostToolUse(Bash, git commit) → warn if CC > 15
-  memory/
-    MEMORY.md              auto-memory index (SSOT)
-    README.md               memory type/usage rules
-  rules/
-    common.md               P0/P1/P2 priority tiers + common workflow (always loaded)
-    security.md              secrets/auth P0 + lockout/admin-seeding rules (paths-scoped)
-    testing.md               test-per-feature, mock-first units, user-perspective assertions
-    data.md                  data-script rules — no bulk staging, explicit encodings
-    README.md                paths-scoped loading + rule-authoring principles
-  skills/
-    skill-evolve/            self-improving meta skill ("Learned warnings" pattern)
-    status/                   multi-stack status check
-    review/                   code-reviewer + security-audit wrapper
-    memory-factcheck/         memory fact-check — verify claims against code/DB/issues, correct stale
-    security-precheck/        pre-audit security sweep → issues → parallel fixes
-    docs-sync/                doc currency — claim-by-claim verification + parallel-language sync
-  workflows/             (not auto-loaded — invoked explicitly)
-    rules-audit.js           stored Workflow example — scan/verify/repair with human merge gate
-  scripts/               (not auto-loaded — invoked explicitly)
-    knowledge_graph.py       .claude ecosystem graph + --check broken-link gate
-  settings.json               hook wiring + default deny rules
-AGENTS.md                 project brain — rule SSOT (P0/P1/P2 + workflow)
-CLAUDE.md                 @AGENTS.md + memory-index import (Claude Code)
-GEMINI.md                 @AGENTS.md + memory-index import (Gemini CLI)
-presets/                  preset fragments (copy-overwrite model)
-  forge-github/           GitHub forge — gh, PRs, `Closes #N` auto-close
-  forge-gitlab/           GitLab forge — glab, MRs, `Closes #N` auto-close (verify after merge)
-  nextjs/ bun/ ...        per-stack fragments (rules + pre-commit.partial.sh + AGENTS.partial.md)
-  lang-en/                English overlay (base/forge-*/stacks/*) — see `--lang` below
-bin/                      agents-scaffold.sh bootstrap script
-tests/                    bats regression suite for the bootstrap script
-```
-
-## Stack presets
-
-| Preset | Rule file | pre-commit gate |
-|--------|-----------|-----------------|
-| `nextjs` | nextjs.md (paths: app/**, components/**) | `tsc --noEmit` |
-| `springboot` | springboot.md (paths: src/main/java/**) | `./gradlew build` |
-| `javaweb` | javaweb.md (paths: src/main/java/**, **/*.jsp) | maven/gradle/ant compile (auto-detect) |
-| `bun` | bun.md (paths: **/*.ts) | `bunx tsc --noEmit` |
-| `python` | python.md (paths: **/*.py) | `ruff check` + `mypy` |
-| `go` | go.md (paths: **/*.go) | `go build ./...` + `vet` + `golangci-lint` |
-| `rust` | rust.md (paths: src/**/*.rs, **/*.rs) | `cargo check` + `clippy` |
-| `android` | android.md (paths: **/*.kt) | `./gradlew ktlintCheck detekt` |
-| `flutter` | flutter.md (paths: **/*.dart, pubspec.yaml) | `dart format` + `flutter analyze` + `test` |
-| `ops` | ops.md (paths: Dockerfile, docker-compose*, quadlet/**, ansible/**) | — |
-
-## Forge presets (`--forge`)
-
-Injects the issue/PR workflow for your forge. Merged before stack presets.
-
-| Preset | CLI | PR/MR | Issue close |
-|--------|-----|-------|-------------|
-| `github` (default) | `gh` | PR | **auto-closed** on merge via `Closes #N` |
-| `gitlab` | `glab` | MR | `Closes #N` auto-close works — verify post-merge, manual only if still open |
-
-Injected files: `.claude/rules/forge.md` (always loaded) plus forge variants of
-`.claude/commands/fix-issue.md` and `sdlc-cycle.md` (overwrite the base). Base
-files stay forge-neutral ("issue / PR·MR").
-
-## Picking a requirements-hardening tool
-
-Three tools harden requirements before implementation, and **they differ enough that you pick per
-task.** Only `grill-me` is bundled; the other two install separately.
-
-| | `grill-me` | superpowers | Ouroboros |
-|---|---|---|---|
-| **Scope** | interrogation only | the whole workflow | interrogate → spec → run → evaluate loop |
-| **State** | stays in the conversation | conversation + file artifacts | an MCP server keeps it persistently |
-| **Weight** | light | medium | heavy — fans out a subagent per question |
-| **Install** | **bundled** (`.claude/skills/grill-me/`) | plugin, [obra/superpowers](https://github.com/obra/superpowers) | marketplace, [Q00/ouroboros](https://github.com/Q00/ouroboros) (ships an MCP server) |
-
-**How to choose**
-
-- A feature that already has direction, and you want the holes in its spec found → **`grill-me`**.
-  Nothing to install, one conversation and you're done.
-- A blank page you need to diverge and converge on, with a document to keep → **superpowers'
-  `brainstorming`**.
-- A large, vaguely specified job that has to be **turned into a spec and then run and evaluated in
-  a loop** → **Ouroboros**. State survives a dropped session, at the highest token cost of the three.
-
-Escalate by weight, and **only upward** — reaching for Ouroboros where the light option would do
-just costs more. None of them fire automatically, even with all three installed; you pick per task.
-
-## Harness (`--harness`)
-
-| Value | Target | What it does |
-|---|---|---|
-| `claude` (default) | Claude Code | Full install — settings.json hook bindings, subagents, slash commands, workflows |
-| `codex` | Codex and other AGENTS.md harnesses | Installs only the harness-neutral layers (AGENTS.md, rules, skills, hooks, memory) and drops the Claude-only layers |
-| `all` | Mixed teams | Full install |
-
-**Support comes in two tiers (#21)** — not a binary "supported / unsupported".
-
-| Tier | What holds | Which harnesses |
-|---|---|---|
-| **baseline** | The P0/P1 tiers in the `AGENTS.md` body (including the selected stack's P0) + a **real `.git/hooks/pre-commit` gate** + CI | **Every harness, whatever `--harness` you passed.** It holds no matter what the harness reads, and it holds when a human commits straight from the terminal |
-| **full** | baseline + that harness's native layers (subagents, skills, slash commands, path-scoped rule loading, lifecycle hooks) | Only harnesses whose adapter has been measured |
-
-The git hook is **always wired, regardless of harness** (#21). Claude Code's `PreToolUse` hook only fires when that session commits through the Bash tool, so it is an early-feedback layer, not the enforcement line — the deterministic line lives outside the harness (`.git/hooks` + CI). An existing `.git/hooks/pre-commit` is never overwritten; you get a warning instead.
-
-The selected stack's P0 rules are **inlined into the `AGENTS.md` body**, so they do not depend on a `.claude/rules/` reference link and stay reachable on harnesses that never load `.claude/`. Stacks you did not select are not inlined (Codex caps combined instructions at 32KiB by default — this avoids context flooding).
-
-### Verified (2026-08-22)
-
-| Harness | Measured version | baseline | What is / isn't confirmed on the full tier |
-|---|---|---|---|
-| Claude Code | 2.1.239 | holds | `paths:`-scoped loading of `.claude/rules/*.md`, subagents, skills, `settings.json` hooks — all confirmed against the [official docs](https://code.claude.com/docs/en/memory.md) |
-| Codex | codex-cli 0.149.0 | holds | `AGENTS.md` auto-load and a P0-cited `.env` refusal were measured. **Skills are not discovered** (see below) |
-| Antigravity | agy **1.1.18** (not re-measured) | holds | On 1.1.17, **headless (`-p`) measurably did not load rules** — root cause unknown. Neither 1.1.18 nor interactive mode has been re-measured |
-
-Codex (codex-cli 0.149.0) auto-loads the `codex`-mode AGENTS.md, answered the rule tiers
-correctly, and **refused an instruction to commit a `.env`, citing the P0 rule** (first line of
-defense). If a model tries anyway, the git hook blocks it with exit 2 (second line, test-covered).
-
-**Known gap — Codex skills are not auto-discovered.** Codex discovers repository skills under
-`.agents/skills`, but `--harness codex` currently leaves them in `.claude/skills`. The rules layer
-(`AGENTS.md`) works; the skills layer does not — that is baseline, not full.
-
-Two further Codex constraints shape the design:
-
-- **Combined instructions are capped at 32KiB by default** (`project_doc_max_bytes`), which is why
-  only the selected stack's P0 is inlined into `AGENTS.md` (measured 6,869 B with `--stack javaweb`
-  — 21% of the cap).
-- **The `.codex/` layer only loads for a trusted project.** Emitting a file does not guarantee it is
-  active, which is why the deterministic enforcement line lives in `.git/hooks` + CI.
-
-## Language (`--lang`)
-
-The base tree (agents, rules, skills, commands, `AGENTS.md`, hook/settings
-messages) is **Korean by default** (#36 inversion — Korean is the source of
-truth, English is the translated overlay). `--lang en` layers the English
-translation on top, applied last — after the base copy, forge preset, and
-stack presets — so it overrides the same files with `presets/lang-en/base` +
-`presets/lang-en/forge-<forge>` + `presets/lang-en/stacks/<stack>` content.
-
-```bash
-agents-scaffold/bin/agents-scaffold.sh /path/to/new-repo --lang en --forge github --stack bun
-```
-
-`.claude/hooks/pre-commit.sh` is never overlaid by `--lang` (it's the file
-stack partials get spliced into — single-language messages, code unaffected
-by language). `--update` only refreshes the Korean base; re-run with
-`--lang en` on top if you need the English overlay reapplied.
-
-## Usage 1 — script
-
-```bash
-git clone https://github.com/leeyudok/agents-scaffold.git
-# --forge defaults to github; use --forge gitlab for GitLab repos
-agents-scaffold/bin/agents-scaffold.sh /path/to/new-repo --forge github --stack nextjs,bun --name my-app
-```
-
-Omit `--forge`/`--stack`/`--name` to run interactively — the script will prompt
-(forge defaults to github).
-
-### Options
-
-| Option | Description |
+| Doc | What's in it |
 |---|---|
-| `<target-dir>` | Target directory. Default `.` |
-| `--forge <forge>` | `github` (default) or `gitlab` |
-| `--lang <lang>` | `ko` (default) or `en` |
-| `--stack <list>` | Comma-separated stack presets. Prompts interactively when omitted |
-| `--name <name>` | `{{PROJECT_NAME}}` substitution value. Default = target directory name |
-| `--yes` | Skip interactive prompts (non-interactive mode) |
-| `--update` | Refresh base files of an already-bootstrapped project (see below) |
-
-### Remote one-command install (no clone)
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/leeyudok/agents-scaffold/main/bin/agents-scaffold.sh | bash -s -- --stack nextjs --yes
-```
-
-When the script detects it is not running from a local checkout (e.g. piped
-execution), it downloads the `AGENTS_SCAFFOLD_REPO` tarball (default:
-`github.com/leeyudok/agents-scaffold`, override via env) into a temporary directory and
-uses it as the template source. Pin a branch/tag with `AGENTS_SCAFFOLD_REF`
-(default `main`).
-
-### Updating the base — `--update`
-
-Applies the latest base files (`.claude/`, `AGENTS.md`, `CLAUDE.md`,
-`GEMINI.md`) to an already-bootstrapped project.
-
-```bash
-agents-scaffold/bin/agents-scaffold.sh --update /path/to/existing-repo
-```
-
-- `.claude/hooks/pre-commit.sh` is always skipped — stack partials were spliced
-  into it, so it needs manual merging.
-- Other base files are skipped when identical; when they differ, the existing
-  file is preserved and the new version is written as `<file>.new`
-  (placeholder substitution applies to `.new` files too).
-- A summary of added / pending-update / skipped / unchanged files is printed at
-  the end — review `.new` files with `diff` and apply manually.
-
-## Usage 2 — GitLab template
-
-To have this configuration applied automatically when creating a new project,
-see **[docs/GITLAB_TEMPLATE.md](docs/GITLAB_TEMPLATE.md)**.
-
-> Note: this workflow assumes a self-hosted GitLab instance. On **GitLab CE**,
-> native custom project templates are a Premium feature and unavailable —
-> use **Import by URL + `bin/agents-scaffold.sh`** or **the script alone** instead.
-> After creating/importing, run `bin/agents-scaffold.sh .` once to apply the
-> chosen stacks, substitute placeholders, and self-clean `bin/`/`presets/`/`docs/superpowers/`.
-
-## Placeholder substitution
-
-| Token | Value |
-|---|---|
-| `{{PROJECT_NAME}}` | `--name` value, or the target directory name |
-| `{{JAVA_VERSION}}` | `1.8` (springboot preset default) |
-
-## Key patterns
-
-- **P0/P1/P2 priority tiers**: defined in `common.md` + `AGENTS.md`. P0 = security/secrets/data destruction, no exceptions.
-- **SDLC role split**: developer/tester/verifier agents + the `/sdlc-cycle` automation command.
-- **skill-evolve / agent-evolve**: a self-improvement pattern that appends "Learned warnings" from mistakes. `skill-evolve` targets `.claude/skills/*.md`, `agent-evolve` targets `.claude/agents/*.md`.
-- **Memory SSOT**: `.claude/memory/` (the system default path is not used). Type prefixes: `project_`/`feedback_`/`reference_`/`user_`.
-- **Paths-scoped rules**: frontmatter `paths:` auto-loads a rule only while working on matching files.
-- **Multi-agent isolation**: when parallel subagents may touch the same file concurrently, use `isolation: "worktree"`.
+| [docs/OPTIONS.en.md](docs/OPTIONS.en.md) | Every option — 10 stack presets, `--forge`, `--harness`, `--lang`, usage, placeholder substitution, picking a requirements-hardening tool |
+| [docs/INTERNALS.en.md](docs/INTERNALS.en.md) | Internals — the full generated `.claude/` tree, key patterns |
+| [CONTRIBUTING.md](CONTRIBUTING.md) | Contribution guide |
 
 ## Contributing
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -5,14 +5,23 @@
 [![tests](https://github.com/leeyudok/agents-scaffold/actions/workflows/test.yml/badge.svg)](https://github.com/leeyudok/agents-scaffold/actions/workflows/test.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
-**フレームワークではありません — AI コーディングエージェントのためのミニマルな fork-and-fill ブートストラップです**。
-ルール階層を**強制**します: P0(即時停止) / P1(PRブロック) / P2(レビュー指摘)。スタックプリセットは
-単一の pre-commit ゲートに合成されます。Claude Code を第一に、Codex など AGENTS.md
-ハーネスは [`--harness`](#ハーネス---harness) で対応します。
+**AI コーディングエージェントはルールを破ります。お願いするのではなく、コミットを止めます。**
+
+コマンド 1 回で `.claude/` 構成と pre-commit ゲートがリポジトリに入ります。フレームワークも
+ランタイムも、接続するレジストリもありません — 手に入るのは**完全にあなたのものである普通のファイル**です。
 
 ![デモ: ワンコマンドのブートストラップ、生成された .claude/ ツリー、ステージングされた .env をブロックする pre-commit ゲート](docs/assets/demo.gif)
 
 _30秒デモ: コマンド1つ → 記入済みの `.claude/` → ゲートがシークレットのコミットをブロック。`vhs docs/assets/demo.tape` で再現できます。_
+
+## こんな覚えがあるなら、これです
+
+- 同じルールを**セッションのたびに説明し直している** — 昨日伝えたことを今日はもう知らない。
+- エージェントが `.env` をステージした。型エラーが残ったままコミットが作られた。
+- メンバーごとに `CLAUDE.md` がばらばらで、**誰のセッションかで結果が変わる。**
+
+ドキュメントに書いただけのルールは、AI がいずれ無視します。このスキャフォールドはルールを
+**コミットを止めるゲート**に変えて、リポジトリに埋め込みます。
 
 ## Quickstart
 
@@ -28,7 +37,21 @@ agents-scaffold/bin/agents-scaffold.sh /path/to/new-repo --forge github --stack 
 記入済みの `.claude/` ディレクトリ(エージェント、スキル、フック、paths スコープの
 ルール、メモリ)、プロジェクトの頭脳となる `AGENTS.md`、そして合成された単一の pre-commit
 ゲートが手に入ります — すべて完全にあなたが所有するプレーンなファイルです。全オプションは
-[Usage](#usage-1--script) を参照してください。
+[Usage](docs/OPTIONS.ja.md#usage-1--script) を参照してください。
+
+## インストール直後に起きること
+
+エージェント(あるいは人)がシークレットをコミットしようとすると、**コミット自体が通りません。**
+
+```console
+$ bash agents-scaffold.sh . --stack python --name payments --yes
+$ echo 'DB_PASSWORD=hunter2' > .env
+$ git add -f .env app.py && git commit -m "feat: add config"
+Blocked: a .env-type file is staged. Commit is not allowed.
+```
+
+ドキュメントに「シークレットをコミットしないこと」と書くのとは違います。止めているのは
+`.git/hooks/pre-commit` なので、**どの AI ツールを使っても、人が手でコミットしても同じように掛かります。**
 
 ## 何が手に入るか — 初心者向け
 
@@ -49,7 +72,7 @@ agents-scaffold/bin/agents-scaffold.sh /path/to/new-repo --forge github --stack 
 - **ワンショットコマンド**: `/review`(コードレビュー + セキュリティ監査)、`/status`、
   `/knowledge-graph`(ドキュメントリンクチェッカー)、`/sonar`。
 - **要件の鍛え込みは 3 つから選択**: 同梱の **`grill-me`** に加えて、用途に応じて外部ツール
-  2 つを組み合わせられます → [要件を鍛えるツールの選び方](#要件を鍛えるツールの選び方)。
+  2 つを組み合わせられます → [要件を鍛えるツールの選び方](docs/OPTIONS.ja.md#要件を鍛えるツールの選び方)。
 - **セッションをまたいで生き残るメモリ**: プロジェクトの学びが
   `.claude/memory/` 配下に蓄積され、次のセッションで自動ロードされ、チームで共有されます。
 - **自己進化**: skill-evolve/agent-evolve が失敗のフィードバックからスキル/エージェント
@@ -75,238 +98,13 @@ agents-scaffold/bin/agents-scaffold.sh /path/to/new-repo --forge github --stack 
 - **テスト済み** — ブートストラップスクリプトには bats のリグレッションスイートが同梱され、
   knowledge-graph リンクチェッカーがドキュメントをゲートします。
 
-## 中身
+## さらに詳しく
 
-```
-.claude/
-  agents/
-    security-audit.md   12項目の P0/P1 セキュリティ grep スキャン
-    db-migration.md      DDL 安全性チェック + ロールバック SQL 生成
-    sdlc-developer.md    最小スコープ実装エージェント(SDLC 役割分離)
-    sdlc-tester.md        AC/TC テスト作成エージェント
-    sdlc-verifier.md      パイプライン実行 + レポートエージェント
-    agent-evolve.md       自己改善メタエージェント — 実行フィードバックから agents/*.md を洗練
-  commands/              （Claude Code ではレガシー — スラッシュコマンドは skills に統合）
-    sonar.md             SonarQube 分析(CE タスクポーリング、sqp_/squ_ トークン処理)
-    sdlc-cycle.md         5段階 SDLC 自動化
-    knowledge-graph.md    .claude ナレッジグラフ再生成 + リンク切れチェック
-  hooks/
-    pre-commit.sh         pre-commit ゲートのスケルトン(スタックパーシャルの挿入点)
-    post-edit-format.sh   PostToolUse(Edit|Write) → 自動フォーマット
-    post-test-notify.sh   PostToolUse(Bash, *test*) → ターミナル通知
-    stop-memory-remind.sh Stop フック → セッションごとに1回のメモリリマインダー
-    cc-check.py            PostToolUse(Bash, git commit) → CC > 15 なら警告
-  memory/
-    MEMORY.md              auto-memory インデックス(SSOT)
-    README.md               メモリのタイプ/利用ルール
-  rules/
-    common.md               P0/P1/P2 優先度階層 + 共通ワークフロー(常時ロード)
-    security.md              シークレット/認証 P0 + ロックアウト/管理者シーディング規則(paths スコープ)
-    testing.md               機能ごとにテスト、mock 優先ユニット、ユーザー視点アサーション
-    data.md                  データスクリプト規則 — 一括ステージング禁止、エンコーディング明示
-    README.md                paths スコープロード + ルール作成原則
-  skills/
-    skill-evolve/            自己改善メタスキル(「Learned warnings」パターン)
-    status/                   マルチスタック状態チェック
-    review/                   code-reviewer + security-audit ラッパー
-    memory-factcheck/         メモリのファクトチェック — 主張をコード/DB/イシューと照合し、古いものを修正
-    security-precheck/        監査前セキュリティスイープ → イシュー化 → 並列修正
-    docs-sync/                ドキュメント現行化 — 主張ごとの事実照合 + 多言語ペアの同時更新
-  workflows/             （自動ロードされない — 明示的に呼び出す）
-    rules-audit.js           保存型 Workflow の例 — scan/verify/repair、マージは人間ゲート
-  scripts/               （自動ロードされない — 明示的に呼び出す）
-    knowledge_graph.py       .claude エコシステムグラフ + --check リンク切れゲート
-  settings.json               フック配線 + デフォルト deny ルール
-AGENTS.md                 プロジェクトの頭脳 — ルール SSOT(P0/P1/P2 + ワークフロー)
-CLAUDE.md                 @AGENTS.md + メモリインデックスの import (Claude Code)
-GEMINI.md                 @AGENTS.md + メモリインデックスの import (Gemini CLI)
-presets/                  プリセット断片(コピー上書きモデル)
-  forge-github/           GitHub forge — gh、PR、`Closes #N` 自動クローズ
-  forge-gitlab/           GitLab forge — glab、MR、`Closes #N` 自動クローズ(マージ後に確認)
-  nextjs/ bun/ ...        スタック別断片(rules + pre-commit.partial.sh + AGENTS.partial.md)
-  lang-en/                英語オーバーレイ(base/forge-*/stacks/*)— 後述の `--lang` を参照
-bin/                      agents-scaffold.sh ブートストラップスクリプト
-tests/                    ブートストラップスクリプト用 bats リグレッションスイート
-```
-
-## スタックプリセット
-
-| プリセット | ルールファイル | pre-commit ゲート |
-|--------|-----------|-----------------|
-| `nextjs` | nextjs.md (paths: app/**, components/**) | `tsc --noEmit` |
-| `springboot` | springboot.md (paths: src/main/java/**) | `./gradlew build` |
-| `javaweb` | javaweb.md (paths: src/main/java/**, **/*.jsp) | maven/gradle/ant compile (自動検出) |
-| `bun` | bun.md (paths: **/*.ts) | `bunx tsc --noEmit` |
-| `python` | python.md (paths: **/*.py) | `ruff check` + `mypy` |
-| `go` | go.md (paths: **/*.go) | `go build ./...` + `vet` + `golangci-lint` |
-| `rust` | rust.md (paths: src/**/*.rs, **/*.rs) | `cargo check` + `clippy` |
-| `android` | android.md (paths: **/*.kt) | `./gradlew ktlintCheck detekt` |
-| `flutter` | flutter.md (paths: **/*.dart, pubspec.yaml) | `dart format` + `flutter analyze` + `test` |
-| `ops` | ops.md (paths: Dockerfile, docker-compose*, quadlet/**, ansible/**) | — |
-
-## Forge プリセット (`--forge`)
-
-利用する forge のイシュー/PR ワークフローを注入します。スタックプリセットより先にマージされます。
-
-| プリセット | CLI | PR/MR | イシュークローズ |
-|--------|-----|-------|-------------|
-| `github` (デフォルト) | `gh` | PR | `Closes #N` によりマージ時に**自動クローズ** |
-| `gitlab` | `glab` | MR | `Closes #N` の自動クローズは動作する — マージ後に確認し、open のままの場合のみ手動 |
-
-注入されるファイル: `.claude/rules/forge.md`(常時ロード)に加え、
-`.claude/commands/fix-issue.md` と `sdlc-cycle.md` の forge 別バリアント(ベースを上書き)。
-ベースファイルは forge 非依存のまま("issue / PR·MR")です。
-
-## 要件を鍛えるツールの選び方
-
-実装前に要件を鍛える手段は 3 つあり、**性格が異なるのでタスクごとに選びます**。同梱されるのは `grill-me` だけで、残る 2 つは別途インストールします。
-
-| | `grill-me` | superpowers | Ouroboros |
-|---|---|---|---|
-| **範囲** | 尋問のみ | ワークフロー全般 | 尋問 → 仕様 → 実行 → 評価のループ |
-| **状態** | 会話の中で完結 | 会話 + ファイル成果物 | MCP サーバーが永続管理 |
-| **重さ** | 軽い | 中 | 重い — 質問ごとにサブエージェントを fanout |
-| **導入** | **同梱**(`.claude/skills/grill-me/`) | プラグイン [obra/superpowers](https://github.com/obra/superpowers) | マーケットプレイス [Q00/ouroboros](https://github.com/Q00/ouroboros)(MCP サーバー同梱) |
-
-**選ぶ基準**
-
-- 方向性が決まった機能の仕様に穴がないか調べたい → **`grill-me`**。インストール不要、会話 1 回で終わります。
-- 白紙のアイデアを発散・収束させ、成果物(ドキュメント)も残したい → **superpowers の `brainstorming`**。
-- 要件が曖昧な大きめの作業を**仕様化し、実行と評価までループで回したい** → **Ouroboros**。セッションが切れても状態は残りますが、トークンコストは 3 つの中で最大です。
-
-重さの順に上げていき、**下から上へだけ**動かします — 軽い手段で足りる作業に Ouroboros を使ってもコストが増えるだけです。3 つとも入っていても自動では発動せず、タスクごとに使う側が選びます。
-
-## ハーネス (`--harness`)
-
-| 値 | 対象 | 動作 |
-|---|---|---|
-| `claude`（デフォルト） | Claude Code | フルインストール — settings.json のフックバインディング・サブエージェント・スラッシュコマンド・workflows を含む |
-| `codex` | Codex ほか AGENTS.md 対応ハーネス | ハーネス中立の層（AGENTS.md・rules・skills・hooks・memory）のみ導入し、Claude 専用層を除去 |
-| `all` | 混在チーム | フルインストール |
-
-**保証レベルは 2 段階です（#21）** — 「対応している/していない」の二分法ではありません。
-
-| レベル | 成立する内容 | 対象ハーネス |
-|---|---|---|
-| **baseline** | `AGENTS.md` 本文の P0/P1（選択したスタックの P0 を含む）+ **実際の `.git/hooks/pre-commit` ゲート** + CI | **`--harness` の値に関係なく全ハーネス。** ハーネスが何を読むかによらず、人が端末から直接コミットしても同じように掛かります |
-| **full** | baseline + そのハーネスのネイティブ層（サブエージェント・skills・スラッシュコマンド・パススコープのルール読み込み・lifecycle フック） | アダプタが実測検証されたハーネスのみ |
-
-git フックは**ハーネスに関係なく常に配線されます**（#21）。Claude Code の `PreToolUse` フックはそのセッションが Bash ツールでコミットしたときにのみ発火するため、早期フィードバック層であって強制線ではありません — 決定的な強制線はハーネスの外（`.git/hooks` + CI）に置きます。既存の `.git/hooks/pre-commit` は上書きせず、警告のみ出します。
-
-選択したスタックの P0 は **`AGENTS.md` 本文に直接挿入**されます。`.claude/rules/` の参照リンクに依存しないため、`.claude/` を読み込まないハーネスでも到達可能です。選択していないスタックは挿入されません（Codex の指示合計はデフォルト 32KiB 上限 — context flooding を防ぐため）。
-
-### 実測検証（2026-08-22）
-
-| ハーネス | 実測バージョン | baseline | full 層で確認できたこと / できていないこと |
-|---|---|---|---|
-| Claude Code | 2.1.239 | 成立 | `.claude/rules/*.md` の `paths:` 条件付きロード、サブエージェント、skills、`settings.json` フック — いずれも[公式ドキュメント](https://code.claude.com/docs/en/memory.md)で確認 |
-| Codex | codex-cli 0.149.0 | 成立 | `AGENTS.md` の自動ロードと P0 を根拠にした `.env` 拒否を実測。**skills は発見されない**（下記） |
-| Antigravity | agy **1.1.18**（再測定なし） | 成立 | 1.1.17 で **headless（`-p`）がルールを読み込まない**ことを実測 — 原因は未解明。1.1.18 もインタラクティブモードも未検証 |
-
-Codex（codex-cli 0.149.0）は `codex` モード成果物の AGENTS.md を自動で読み込み、ルール階層を正しく回答し、`.env` をコミットせよという指示を **P0 ルールを根拠に自ら拒否**しました（第一の防衛線）。モデルが強行しても git フックが exit 2 でブロックします（第二の防衛線、テスト済み）。
-
-**既知のギャップ — Codex の skills は自動発見されません。** Codex がリポジトリの skills を探す場所は `.agents/skills` ですが、現在の `--harness codex` は `.claude/skills` に残します。ルール層（`AGENTS.md`）は機能しますが skills 層は機能しません — これは full ではなく baseline です。
-
-Codex 側の制約がもう 2 点、設計に効いてきます。
-
-- **指示の合計はデフォルト 32KiB 上限**（`project_doc_max_bytes`）。そのため選択したスタックの P0 のみを `AGENTS.md` にインライン化します（`--stack javaweb` で実測 6,869 B — 上限の 21%）。
-- **`.codex/` レイヤは信頼済みプロジェクトでのみロードされます。** ファイルを生成しても有効化は保証されません。だからこそ決定的な強制線は `.git/hooks` + CI に置きます。
-
-## 言語 (`--lang`)
-
-ベースツリー(エージェント、ルール、スキル、コマンド、`AGENTS.md`、フック/settings の
-メッセージ)は**デフォルトで韓国語**です(#36 での反転 — 韓国語が単一の真実源で、
-英語は翻訳オーバーレイ)。`--lang en` は英訳を最後に重ねます — ベースコピー、
-forge プリセット、スタックプリセットの後に適用されるため、同じファイルを
-`presets/lang-en/base` + `presets/lang-en/forge-<forge>` + `presets/lang-en/stacks/<stack>`
-の内容で上書きします。
-
-```bash
-agents-scaffold/bin/agents-scaffold.sh /path/to/new-repo --lang en --forge github --stack bun
-```
-
-`.claude/hooks/pre-commit.sh` は `--lang` によるオーバーレイの対象外です
-(スタックパーシャルが挿入されるファイルであり、メッセージは単一言語、コードは
-言語の影響を受けません)。`--update` は韓国語のベースのみを更新します。英語
-オーバーレイを再適用したい場合は、その上で `--lang en` を付けて再実行してください。
-
-## Usage 1 — script
-
-```bash
-git clone https://github.com/leeyudok/agents-scaffold.git
-# --forge のデフォルトは github。GitLab リポジトリには --forge gitlab を使う
-agents-scaffold/bin/agents-scaffold.sh /path/to/new-repo --forge github --stack nextjs,bun --name my-app
-```
-
-`--forge`/`--stack`/`--name` を省略すると対話モードで実行され、スクリプトが
-プロンプトを表示します(forge のデフォルトは github)。
-
-### オプション
-
-| オプション | 説明 |
+| ドキュメント | 内容 |
 |---|---|
-| `<target-dir>` | 対象ディレクトリ。デフォルト `.` |
-| `--forge <forge>` | `github`(デフォルト)または `gitlab` |
-| `--lang <lang>` | `ko`(デフォルト)または `en` |
-| `--stack <list>` | カンマ区切りのスタックプリセット。省略時は対話的にプロンプト |
-| `--name <name>` | `{{PROJECT_NAME}}` の置換値。デフォルトは対象ディレクトリ名 |
-| `--yes` | 対話プロンプトをスキップ(非対話モード) |
-| `--update` | ブートストラップ済みプロジェクトのベースファイルを更新(後述) |
-
-### リモートワンコマンドインストール(クローン不要)
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/leeyudok/agents-scaffold/main/bin/agents-scaffold.sh | bash -s -- --stack nextjs --yes
-```
-
-スクリプトはローカルチェックアウトから実行されていないこと(パイプ実行など)を検知すると、
-`AGENTS_SCAFFOLD_REPO` の tarball(デフォルト: `github.com/leeyudok/agents-scaffold`、
-環境変数で上書き可)を一時ディレクトリにダウンロードし、テンプレートソースとして
-使用します。ブランチ/タグの固定は `AGENTS_SCAFFOLD_REF`(デフォルト `main`)で行います。
-
-### ベースの更新 — `--update`
-
-ブートストラップ済みプロジェクトに最新のベースファイル(`.claude/`、`AGENTS.md`、
-`CLAUDE.md`、`GEMINI.md`)を適用します。
-
-```bash
-agents-scaffold/bin/agents-scaffold.sh --update /path/to/existing-repo
-```
-
-- `.claude/hooks/pre-commit.sh` は常にスキップされます — スタックパーシャルが
-  挿入済みのため、手動マージが必要です。
-- その他のベースファイルは、内容が同一ならスキップされます。差分がある場合は
-  既存ファイルを保持し、新バージョンを `<file>.new` として書き出します
-  (プレースホルダー置換は `.new` ファイルにも適用されます)。
-- 最後に追加 / 更新保留 / スキップ / 変更なしのファイルのサマリーが出力されます —
-  `.new` ファイルを `diff` で確認し、手動で適用してください。
-
-## Usage 2 — GitLab テンプレート
-
-新規プロジェクト作成時にこの設定を自動適用するには、
-**[docs/GITLAB_TEMPLATE.md](docs/GITLAB_TEMPLATE.md)** を参照してください。
-
-> 注: このワークフローはセルフホストの GitLab インスタンスを前提とします。**GitLab CE** では
-> ネイティブのカスタムプロジェクトテンプレートは Premium 機能のため利用できません —
-> 代わりに **Import by URL + `bin/agents-scaffold.sh`**、または**スクリプト単体**を使ってください。
-> 作成/インポート後に `bin/agents-scaffold.sh .` を1回実行すると、選択したスタックの適用、
-> プレースホルダー置換、`bin/`/`presets/`/`docs/superpowers/` のセルフクリーンが行われます。
-
-## プレースホルダー置換
-
-| トークン | 値 |
-|---|---|
-| `{{PROJECT_NAME}}` | `--name` の値、または対象ディレクトリ名 |
-| `{{JAVA_VERSION}}` | `1.8`(springboot プリセットのデフォルト) |
-
-## 主要パターン
-
-- **P0/P1/P2 優先度階層**: `common.md` + `AGENTS.md` で定義。P0 = セキュリティ/シークレット/データ破壊、例外なし。
-- **SDLC 役割分離**: developer/tester/verifier エージェント + `/sdlc-cycle` 自動化コマンド。
-- **skill-evolve / agent-evolve**: ミスから「Learned warnings」を追記する自己改善パターン。`skill-evolve` は `.claude/skills/*.md`、`agent-evolve` は `.claude/agents/*.md` が対象。
-- **メモリ SSOT**: `.claude/memory/`(システムデフォルトパスは使用しない)。タイプ接頭辞: `project_`/`feedback_`/`reference_`/`user_`。
-- **paths スコープのルール**: frontmatter の `paths:` により、マッチするファイルの作業中のみルールを自動ロード。
-- **マルチエージェント分離**: 並列サブエージェントが同一ファイルを同時に触る可能性がある場合は `isolation: "worktree"` を使用。
+| [docs/OPTIONS.ja.md](docs/OPTIONS.ja.md) | 全オプション — スタックプリセット 10 種、`--forge`、`--harness`、`--lang`、使い方、プレースホルダー置換、要件を鍛えるツールの選び方 |
+| [docs/INTERNALS.ja.md](docs/INTERNALS.ja.md) | 内部構造 — 生成される `.claude/` の全ツリー、主要パターン |
+| [CONTRIBUTING.md](CONTRIBUTING.md) | コントリビュートガイド |
 
 ## コントリビュート
 

--- a/README.md
+++ b/README.md
@@ -5,14 +5,23 @@
 [![tests](https://github.com/leeyudok/agents-scaffold/actions/workflows/test.yml/badge.svg)](https://github.com/leeyudok/agents-scaffold/actions/workflows/test.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
-**프레임워크가 아니라 fork-and-fill 미니멀 부트스트랩** — AI 코딩 에이전트용 `.claude/` 초기
-구성에 **강제되는** 규칙 티어 P0(즉시 중단)/P1(PR 차단)/P2(리뷰 지적)를 얹고, 스택
-프리셋을 pre-commit 게이트 하나로 합성한다. Claude Code 우선이며, Codex 등 AGENTS.md
-하네스는 [`--harness`](#하네스---harness) 로 지원한다.
+**AI 코딩 에이전트가 규칙을 안 지키는 문제를, 커밋을 막아서 해결한다.**
+
+명령 한 번이면 `.claude/` 구성과 pre-commit 게이트가 레포에 깔린다. 프레임워크도 런타임도
+설치할 레지스트리도 없다 — 결과물은 전부 **당신이 소유하는 평범한 파일**이다.
 
 ![데모: 원커맨드 부트스트랩 → 생성된 .claude/ 트리 → pre-commit 게이트가 .env 커밋을 차단](docs/assets/demo.gif)
 
 _30초 데모: 명령 한 번 → `.claude/` 완성 → 시크릿 커밋은 게이트가 차단. 재현은 `vhs docs/assets/demo.tape`._
+
+## 이런 적 있으면 이 도구다
+
+- AI 에게 같은 규칙을 **매 세션 다시 설명**하고 있다 — 어제 말한 걸 오늘 또 모른다.
+- 에이전트가 `.env` 를 스테이징하거나, 타입 에러가 있는 채로 커밋을 만들었다.
+- 팀원마다 `CLAUDE.md` 가 제각각이라 **누구 세션이냐에 따라 결과가 다르다.**
+
+규칙을 문서에만 적어두면 AI 는 언젠가 무시한다. 이 스캐폴드는 규칙을 **커밋을 막는
+게이트**로 바꿔 레포에 심는다.
 
 ## 퀵스타트
 
@@ -27,7 +36,21 @@ agents-scaffold/bin/agents-scaffold.sh /path/to/new-repo --forge github --stack 
 
 결과물은 채워진 `.claude/` 디렉터리(agents·skills·hooks·paths 스코프 rules·memory),
 `AGENTS.md` 프로젝트 브레인, 합성된 pre-commit 게이트 하나 — 전부 직접 소유하는 평범한
-파일이다. 전체 옵션은 [사용법](#사용법-1--스크립트) 참조.
+파일이다. 전체 옵션은 [사용법](docs/OPTIONS.md#사용법-1--스크립트) 참조.
+
+## 설치 직후 이런 일이 벌어진다
+
+에이전트가(또는 사람이) 시크릿을 커밋하려 하면 **커밋 자체가 안 된다.**
+
+```console
+$ bash agents-scaffold.sh . --stack python --name payments --yes
+$ echo 'DB_PASSWORD=hunter2' > .env
+$ git add -f .env app.py && git commit -m "feat: add config"
+Blocked: a .env-type file is staged. Commit is not allowed.
+```
+
+문서에 "시크릿 커밋하지 마세요"라고 적어두는 것과 다르다. `.git/hooks/pre-commit` 이
+막기 때문에 **어떤 AI 도구를 쓰든, 사람이 터미널에서 직접 커밋하든 똑같이 걸린다.**
 
 ## 무엇을 얻나 — 입문자 기준
 
@@ -47,7 +70,7 @@ agents-scaffold/bin/agents-scaffold.sh /path/to/new-repo --forge github --stack 
 - **명령 한 방 시리즈**: `/review`(코드리뷰+보안감사 이중), `/status`,
   `/knowledge-graph`(문서 링크 검사), `/sonar`.
 - **요구사항 다지기는 셋 중 골라서**: 동봉된 **`grill-me`** 외에 외부 도구 둘을 상황에
-  맞게 붙일 수 있다 → [요구사항 다지기 도구 고르기](#요구사항-다지기-도구-고르기).
+  맞게 붙일 수 있다 → [요구사항 다지기 도구 고르기](docs/OPTIONS.md#요구사항-다지기-도구-고르기).
 - **세션이 끝나도 기억**: `.claude/memory/` 에 프로젝트 러닝이 쌓여 다음 세션에 자동
   로드되고 팀과 공유된다.
 - **스스로 진화**: skill-evolve/agent-evolve 가 실패 피드백으로 스킬·에이전트 정의를
@@ -71,239 +94,13 @@ placeholder 를 채우고 안 쓰는 걸 지우면, 결과는 레포의 다른 �
 - **테스트됨** — 부트스트랩 스크립트는 bats 회귀 스위트, 문서는 지식그래프 링크 체커가
   게이트한다.
 
-## 무엇이 들어있나
+## 더 보기
 
-```
-.claude/
-  agents/
-    security-audit.md   12-item P0/P1 보안 그레프 스캔
-    db-migration.md     DDL 안전성 검증 + 롤백 SQL 생성
-    sdlc-developer.md   최소 범위 구현 에이전트 (SDLC 역할 분리)
-    sdlc-tester.md      AC/TC 테스트 작성 에이전트
-    sdlc-verifier.md    파이프라인 실행·리포트 에이전트
-    agent-evolve.md     자기개선 메타 에이전트 — 실행 피드백으로 agents/*.md 자동 개선
-  commands/            (Claude Code 에서는 레거시 — 슬래시 커맨드가 skills 로 통합됨)
-    sonar.md            SonarQube 분석 (CE task 폴링, sqp_/squ_ 구분)
-    sdlc-cycle.md       5단계 SDLC 자동화
-    knowledge-graph.md  .claude 지식 그래프 재생성 + 깨진 링크 체크
-  hooks/
-    pre-commit.sh       pre-commit 게이트 골격 (스택 partial 진입점)
-    post-edit-format.sh PostToolUse(Edit|Write) → 자동 포맷
-    post-test-notify.sh PostToolUse(Bash, *test*) → 터미널 알림
-    stop-memory-remind.sh Stop hook → 세션-once 메모리 리마인드
-    cc-check.py         PostToolUse(Bash, git commit) → CC > 15 경고
-  memory/
-    MEMORY.md           auto-memory 인덱스 (SSOT)
-    README.md           메모리 타입·운용 규칙
-  rules/
-    common.md           P0/P1/P2 우선순위 체계 + 공통 워크플로 (항상 로드)
-    security.md         시크릿/인증 P0 + 록아웃·관리자 주입 규칙 (paths 스코프)
-    testing.md          기능당 1테스트, mock 단위 우선, 사용자 관점 어설션
-    data.md             데이터 스크립트 규칙 — 대량 스테이징 금지, 인코딩 명시
-    README.md           paths 스코프 로드 + 룰 작성 원칙
-  skills/
-    skill-evolve/       자기개선 메타 스킬 (Learned warnings 패턴)
-    status/             멀티스택 상태 체크
-    review/             code-reviewer + security-audit 래퍼
-    memory-factcheck/   메모리 사실 검증 — 코드·DB·이슈 대조로 stale 정정
-    security-precheck/  감사 대비 보안 사전점검 → 이슈 → 병렬 수정
-    docs-sync/          문서 현행화 — 주장별 사실 대조 + 다국어 짝 파일 동시 갱신
-  workflows/            (자동 로드 아님 — 명시 호출로만 실행)
-    rules-audit.js      저장형 Workflow 예제 — 스캔/검증/수정, 머지는 사람 게이트
-  scripts/              (자동 로드 아님 — 명시 호출로만 실행)
-    knowledge_graph.py  .claude 생태계 그래프 + --check 깨진 링크 게이트
-  settings.json         hooks 와이어링 + deny 기본값
-AGENTS.md               프로젝트 브레인 — 규칙 SSOT (P0/P1/P2 + 워크플로)
-CLAUDE.md               @AGENTS.md + 메모리 인덱스 import (Claude Code)
-GEMINI.md               @AGENTS.md + 메모리 인덱스 import (Gemini CLI)
-presets/                프리셋 조각 (복사 덮어쓰기 방식)
-  forge-github/         GitHub forge — gh, PR, `Closes #N` 자동 클로즈
-  forge-gitlab/         GitLab forge — glab, MR, `Closes #N` 자동 클로즈(머지 후 확인)
-  nextjs/ bun/ ...      스택별 조각 (rules + pre-commit.partial.sh + AGENTS.partial.md)
-  lang-en/              영어 오버레이 (base/forge-*/stacks/*) — 아래 `--lang` 참조
-bin/                    agents-scaffold.sh 부트스트랩 스크립트
-```
-
-## 스택 프리셋
-
-| 프리셋 | 룰 파일 | pre-commit 게이트 |
-|--------|---------|-----------------|
-| `nextjs` | nextjs.md (paths: app/**, components/**) | `tsc --noEmit` |
-| `springboot` | springboot.md (paths: src/main/java/**) | `./gradlew build` |
-| `javaweb` | javaweb.md (paths: src/main/java/**, **/*.jsp) | maven/gradle/ant 컴파일 (자동 감지) |
-| `bun` | bun.md (paths: **/*.ts) | `bunx tsc --noEmit` |
-| `python` | python.md (paths: **/*.py) | `ruff check` + `mypy` |
-| `go` | go.md (paths: **/*.go) | `go build ./...` + `vet` + `golangci-lint` |
-| `rust` | rust.md (paths: src/**/*.rs, **/*.rs) | `cargo check` + `clippy` |
-| `android` | android.md (paths: **/*.kt) | `./gradlew ktlintCheck detekt` |
-| `flutter` | flutter.md (paths: **/*.dart, pubspec.yaml) | `dart format` + `flutter analyze` + `test` |
-| `ops` | ops.md (paths: Dockerfile, docker-compose*, quadlet/**, ansible/**) | — |
-
-## Forge 프리셋 (`--forge`)
-
-이슈/PR 워크플로를 forge 별로 주입한다. 스택 프리셋보다 먼저 머지된다.
-
-| 프리셋 | CLI | PR/MR | 이슈 클로즈 |
-|--------|-----|-------|------------|
-| `github` (기본) | `gh` | PR | `Closes #N` 로 머지 시 **자동 클로즈** |
-| `gitlab` | `glab` | MR | `Closes #N` 자동 클로즈 동작 — 머지 후 확인, `opened` 시만 수동 |
-
-주입 파일: `.claude/rules/forge.md`(항상 로드) + `.claude/commands/fix-issue.md`·`sdlc-cycle.md`(forge 변형으로 덮어씀). 베이스 파일은 forge 중립("이슈/PR·MR").
-
-## 요구사항 다지기 도구 고르기
-
-구현 전에 요구사항을 다지는 수단은 세 가지고, **성격이 서로 다르니 작업마다 골라 쓴다.**
-동봉되는 것은 `grill-me` 하나뿐이고 나머지 둘은 별도 설치다.
-
-| | `grill-me` | superpowers | Ouroboros |
-|---|---|---|---|
-| **범위** | 취조만 | 워크플로 전반 | 취조 → 스펙 → 실행 → 평가 루프 |
-| **상태** | 대화 안에서 끝 | 대화 + 파일 산출물 | MCP 서버가 영속 관리 |
-| **무게** | 가벼움 | 중간 | 무거움 — 질문마다 서브에이전트 fanout |
-| **설치** | **동봉** (`.claude/skills/grill-me/`) | 플러그인 [obra/superpowers](https://github.com/obra/superpowers) | 마켓플레이스 [Q00/ouroboros](https://github.com/Q00/ouroboros) (MCP 서버 동반) |
-
-**고르는 기준**
-
-- 이미 방향이 선 기능의 스펙에 구멍이 있는지 → **`grill-me`**. 설치 없이 바로, 대화 한 판으로 끝난다.
-- 백지 아이디어를 발산·수렴하고 산출물(문서)까지 남겨야 함 → **superpowers 의 `brainstorming`**.
-- 요구사항이 모호한 큰 작업을 **스펙화하고 실행·평가까지 루프로 돌려야 함** → **Ouroboros**.
-  세션이 끊겨도 상태가 남는 대신 토큰 비용이 가장 크다.
-
-무게 순으로 올라가되, **아래에서 위로만 간다** — 가벼운 걸로 충분한 작업에 Ouroboros 를
-쓰면 비용만 커진다. 셋 다 설치돼 있어도 자동 발동은 안 하며, 작업마다 사용자가 택일한다.
-
-## 하네스 (`--harness`)
-
-| 값 | 대상 | 하는 일 |
-|---|---|---|
-| `claude` (기본) | Claude Code | 전체 설치 — settings.json 훅 바인딩·서브에이전트·슬래시 커맨드·workflows 포함 |
-| `codex` | Codex 등 AGENTS.md 하네스 | 하네스 중립 계층(AGENTS.md·rules·skills·hooks·memory)만 설치, Claude 전용 계층 제거 |
-| `all` | 혼용 팀 | 전체 설치 |
-
-**보장 수준은 2단이다 (#21)** — "지원한다/안 한다" 이분법이 아니다.
-
-| 수준 | 무엇이 성립하나 | 어느 하네스에서 |
-|---|---|---|
-| **baseline** | `AGENTS.md` 본문의 P0/P1(선택한 스택 P0 포함) + **진짜 `.git/hooks/pre-commit` 게이트** + CI | **전 하네스, `--harness` 값 무관.** 하네스가 무엇을 읽든, 사람이 터미널에서 직접 커밋하든 동일하게 걸린다 |
-| **full** | baseline + 그 하네스의 네이티브 계층(서브에이전트·스킬·슬래시 커맨드·조건부 룰 로딩·lifecycle 훅) | 어댑터가 실측 검증된 하네스만 |
-
-git hook 은 **하네스와 무관하게 항상 배선된다**(#21). Claude Code 의 `PreToolUse` 훅은 그 세션이
-Bash 툴로 커밋할 때만 발동하므로 조기 피드백 계층이지 강제선이 아니다 — 결정적 강제선은
-하네스 밖(`.git/hooks` + CI)에 둔다. 기존 `.git/hooks/pre-commit` 이 있으면 덮어쓰지 않고 경고만 낸다.
-
-선택한 스택의 P0 는 `AGENTS.md` **본문에 직접 삽입**된다 — `.claude/rules/` 참조 링크에 의존하지
-않으므로 `.claude/` 를 로드하지 않는 하네스에서도 도달 가능하다. 선택하지 않은 스택은 삽입되지
-않는다(Codex instruction 합산 기본 한도 32KiB — context flooding 방지).
-
-### 실측 검증 (2026-08-22)
-
-| 하네스 | 실측 버전 | baseline | full 쪽 확인된 것 / 확인 안 된 것 |
-|---|---|---|---|
-| Claude Code | 2.1.239 | 성립 | `.claude/rules/*.md` 의 `paths:` 조건부 로딩, 서브에이전트, skills, `settings.json` 훅 — 전부 [공식 문서](https://code.claude.com/docs/en/memory.md)로 확인 |
-| Codex | codex-cli 0.149.0 | 성립 | `AGENTS.md` 자동 로드·P0 근거 `.env` 거부까지 실측. **스킬은 발견되지 않는다**(아래) |
-| Antigravity | agy **1.1.18** (미재검증) | 성립 | 1.1.17 에서 **headless(`-p`) 규칙 미로드** 실측 — 원인 미규명. 1.1.18 재검증·인터랙티브 모드 모두 미실시 |
-
-Codex(codex-cli 0.149.0)는 `codex` 모드 산출물의 AGENTS.md 를 자동 로드해 룰 티어를 정확히
-답했고, `.env` 커밋 지시를 **P0 규칙을 근거로 스스로 거부**했다(1차 방어). 모델이 시도해도
-git hook 이 exit 2 로 차단한다(2차 방어, 테스트 커버).
-
-**알려진 갭 — Codex 스킬은 자동 발견되지 않는다.** Codex 의 저장소 스킬 발견 경로는
-`.agents/skills` 인데 현재 `--harness codex` 는 `.claude/skills` 를 남긴다. 규칙 계층
-(`AGENTS.md`)은 동작하지만 스킬은 그렇지 않다 — full 이 아니라 baseline 이다.
-
-Codex 쪽 추가 제약 두 가지도 설계에 영향을 준다.
-
-- **instruction 합산 기본 한도 32KiB** (`project_doc_max_bytes`). 그래서 스택 P0 는 선택한
-  스택만 `AGENTS.md` 에 인라인한다 (`--stack javaweb` 기준 실측 6,869 B — 한도의 21%).
-- **`.codex/` 레이어는 프로젝트를 신뢰한 경우에만 로드된다.** 파일을 생성했다고 활성화가
-  보장되지 않는다. 그래서 결정적 강제선을 `.git/hooks` + CI 에 둔다.
-
-## 언어 (`--lang`)
-
-베이스 트리(agents·rules·skills·commands·`AGENTS.md`·훅/settings 메시지)는 **기본이
-한국어다**(#36 반전 — 한국어가 원본, 영어는 번역 오버레이). `--lang en` 을 주면 영어
-번역을 **가장 마지막에** 얹는다 — 베이스 복사 → forge 프리셋 → 스택 프리셋이 끝난 뒤
-`presets/lang-en/base` + `presets/lang-en/forge-<forge>` + `presets/lang-en/stacks/<stack>`
-콘텐츠로 동일 파일을 덮어쓴다.
-
-```bash
-agents-scaffold/bin/agents-scaffold.sh /path/to/new-repo --lang en --forge github --stack bun
-```
-
-`.claude/hooks/pre-commit.sh` 는 `--lang` 오버레이 대상이 아니다(스택 파셜이 삽입되는
-파일이라 언어 단일본 — 코드 동작에는 영향 없음). `--update` 는 한국어 베이스만
-갱신하므로, 영어 오버레이가 필요하면 `--lang en` 으로 다시 실행한다.
-
-## 사용법 1 — 스크립트
-
-```bash
-git clone https://github.com/leeyudok/agents-scaffold.git
-# --forge 기본값 github. GitLab 레포면 --forge gitlab
-agents-scaffold/bin/agents-scaffold.sh /path/to/new-repo --forge github --stack nextjs,bun --name my-app
-```
-
-대화형으로 쓰려면 `--forge`/`--stack`/`--name` 생략 → 프롬프트가 묻는다(forge 기본 github).
-
-### 옵션
-
-| 옵션 | 설명 |
+| 문서 | 내용 |
 |---|---|
-| `<target-dir>` | 대상 디렉터리. 기본 `.` |
-| `--forge <forge>` | `github`(기본) 또는 `gitlab` |
-| `--lang <lang>` | `ko`(기본) 또는 `en` |
-| `--stack <목록>` | 쉼표구분 스택 프리셋. 미지정 시 대화형 프롬프트 |
-| `--name <name>` | `{{PROJECT_NAME}}` 치환값. 기본 = 대상 디렉터리명 |
-| `--yes` | 대화형 프롬프트 생략(비대화 모드) |
-| `--update` | 이미 부트스트랩된 프로젝트의 베이스 파일 최신화 (아래 참조) |
-
-### 원격 원커맨드 설치 (clone 불필요)
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/leeyudok/agents-scaffold/main/bin/agents-scaffold.sh | bash -s -- --stack nextjs --yes
-```
-
-로컬에 레포가 없는 상태(파이프 실행)로 감지되면 `AGENTS_SCAFFOLD_REPO`(기본
-`github.com/leeyudok/agents-scaffold`, env 로 오버라이드) tarball 을 임시 디렉터리에 받아 템플릿 소스로 쓴다. 브랜치/태그 지정은
-`AGENTS_SCAFFOLD_REF`(기본 `main`) 로 오버라이드.
-
-### 베이스 갱신 — `--update`
-
-이미 부트스트랩된 프로젝트에 최신 베이스(`.claude/`, `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`)를
-반영한다.
-
-```bash
-agents-scaffold/bin/agents-scaffold.sh --update /path/to/existing-repo
-```
-
-- `.claude/hooks/pre-commit.sh` 는 스택 파셜이 삽입돼 있어 항상 건너뛴다(수동 병합 필요).
-- 그 외 베이스 파일은 대상과 diff 없으면 스킵, 다르면 기존 파일은 그대로 두고 새 버전을
-  `<file>.new` 로 저장한다. `{{PLACEHOLDER}}` 치환은 `.new` 파일에도 적용된다.
-- 실행 끝에 추가/갱신 대기/건너뜀/변경없음 목록을 요약 출력 — `.new` 파일은 `diff` 로 확인 후
-  수동 반영.
-
-## 사용법 2 — GitLab 템플릿
-
-새 프로젝트 생성 시 구성을 자동으로 깔리게 하는 법은 **[docs/GITLAB_TEMPLATE.md](docs/GITLAB_TEMPLATE.md)** 참조.
-
-> 주의: self-hosted GitLab 기준. **CE** 는 네이티브 커스텀 프로젝트 템플릿(Premium)이 불가.
-> CE 에서는 **Import by URL + `bin/agents-scaffold.sh`**(B안) 또는 **스크립트 단독**(C안)을 쓴다.
-> 생성/주입 후 `bin/agents-scaffold.sh .` 1회 실행 → 스택 적용 + 치환 + `bin/`·`presets/`·`docs/superpowers/` self-clean.
-
-## 치환 플레이스홀더
-
-| 토큰 | 값 |
-|---|---|
-| `{{PROJECT_NAME}}` | `--name` 또는 대상 디렉터리명 |
-| `{{JAVA_VERSION}}` | `1.8` (springboot 프리셋 기본) |
-
-## 주요 패턴
-
-- **P0/P1/P2 우선순위**: `common.md` + `AGENTS.md` 에 정의. P0 = 보안/시크릿/데이터 파괴, 예외 없음.
-- **SDLC 역할 분리**: developer/tester/verifier 에이전트 + `/sdlc-cycle` 자동화 명령.
-- **skill-evolve / agent-evolve**: 실수에서 "Learned warnings" 추가하는 자기개선 패턴. skill-evolve는 `.claude/skills/*.md`, agent-evolve는 `.claude/agents/*.md` 대상.
-- **메모리 SSOT**: `.claude/memory/`(시스템 기본 경로 미사용). 타입접두 `project_`/`feedback_`/`reference_`/`user_`.
-- **paths 스코프 룰**: frontmatter `paths:` 로 해당 파일 작업 시에만 자동 로드.
-- **멀티에이전트 격리**: 병렬 서브에이전트 파일 동시수정 → `isolation: "worktree"`.
+| [docs/OPTIONS.md](docs/OPTIONS.md) | 전체 옵션 — 스택 프리셋 10종, `--forge`, `--harness`, `--lang`, 사용법, 치환 플레이스홀더, 요구사항 다지기 도구 선택 |
+| [docs/INTERNALS.md](docs/INTERNALS.md) | 내부 구조 — 생성되는 `.claude/` 전체 트리, 주요 패턴 |
+| [CONTRIBUTING.md](CONTRIBUTING.md) | 기여 가이드 |
 
 ## Contributing
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -5,14 +5,21 @@
 [![tests](https://github.com/leeyudok/agents-scaffold/actions/workflows/test.yml/badge.svg)](https://github.com/leeyudok/agents-scaffold/actions/workflows/test.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
-**这不是一个框架，而是一套极简的、fork 后按需填充的 AI 编码代理引导脚手架**，
-自带**强制执行**的规则分级：P0（立即中止）/ P1（阻断 PR）/ P2（评审提示）。各技术栈预设
-会组合进单一的 pre-commit 门禁。以 Claude Code 为先，Codex 等 AGENTS.md harness
-通过 [`--harness`](#harness--harness) 支持。
+**AI 编码代理不守规则。这个工具不是好言相劝，而是直接拦下提交。**
+
+一条命令，就把 `.claude/` 配置和 pre-commit 门禁装进你的仓库。没有框架、没有运行时、没有要接入的注册中心 — 你得到的是**完全归你所有的普通文件。**
 
 ![演示：一条命令完成引导、生成的 .claude/ 目录树，以及 pre-commit 门禁拦截暂存的 .env](docs/assets/demo.gif)
 
 _30 秒演示：一条命令 → 填充完毕的 `.claude/` → 门禁拦截了一次泄露密钥的提交。可用 `vhs docs/assets/demo.tape` 复现。_
+
+## 如果你遇到过这些，就该用它
+
+- 你在**每个会话里重复讲同样的规则** — 昨天说过的，今天又不认识了。
+- 代理把 `.env` 加进了暂存区，或者带着类型错误就生成了提交。
+- 每个同事的 `CLAUDE.md` 都不一样，**结果取决于是谁的会话。**
+
+只写在文档里的规则，AI 迟早会无视。这个脚手架把规则变成**能拦住提交的门禁**，并把它种进仓库。
 
 ## Quickstart
 
@@ -27,7 +34,20 @@ agents-scaffold/bin/agents-scaffold.sh /path/to/new-repo --forge github --stack 
 
 你将得到一个填充完毕的 `.claude/` 目录（agents、skills、hooks、按路径作用域加载的
 规则、memory）、一份作为项目大脑的 `AGENTS.md`，以及一个组合而成的 pre-commit
-门禁——全部是完全归你所有的普通文件。完整选项见 [Usage](#usage-1--脚本)。
+门禁——全部是完全归你所有的普通文件。完整选项见 [Usage](docs/OPTIONS.zh.md#usage-1--脚本)。
+
+## 装好之后会发生什么
+
+当代理（或人）试图提交密钥时，**提交根本不会发生。**
+
+```console
+$ bash agents-scaffold.sh . --stack python --name payments --yes
+$ echo 'DB_PASSWORD=hunter2' > .env
+$ git add -f .env app.py && git commit -m "feat: add config"
+Blocked: a .env-type file is staged. Commit is not allowed.
+```
+
+这与在文档里写一句"不要提交密钥"完全不同。拦下它的是 `.git/hooks/pre-commit`，因此**无论你用哪个 AI 工具，也无论是人在终端手动提交，都一样会被拦住。**
 
 ## 你会得到什么 — 写给新手
 
@@ -48,7 +68,7 @@ prompt 编写也没关系：
 - **一键命令**：`/review`（代码评审 + 安全审计）、`/status`、
   `/knowledge-graph`（文档链接检查器）、`/sonar`。
 - **需求打磨，三种方式任选**：除内置的 **`grill-me`** 外，还可按场景接入两个外部工具 →
-  [挑选需求打磨工具](#挑选需求打磨工具)。
+  [挑选需求打磨工具](docs/OPTIONS.zh.md#挑选需求打磨工具)。
 - **跨会话留存的记忆**：项目经验持续沉淀在 `.claude/memory/` 下，
   下次会话自动加载，并与团队共享。
 - **自我进化**：skill-evolve/agent-evolve 会根据失败反馈重写 skill/agent
@@ -73,238 +93,13 @@ prompt 编写也没关系：
 - **经过测试** —— 引导脚本附带 bats 回归测试套件，知识图谱链接
   检查器为文档把关。
 
-## 内含什么
+## 了解更多
 
-```
-.claude/
-  agents/
-    security-audit.md   12 项 P0/P1 安全 grep 扫描
-    db-migration.md      DDL 安全检查 + 回滚 SQL 生成
-    sdlc-developer.md    最小范围实现 agent（SDLC 角色分离）
-    sdlc-tester.md        AC/TC 测试编写 agent
-    sdlc-verifier.md      流水线执行 + 报告 agent
-    agent-evolve.md       自我改进元 agent —— 根据运行反馈打磨 agents/*.md
-  commands/              （在 Claude Code 上属遗留 — 斜杠命令已并入 skills）
-    sonar.md             SonarQube 分析（CE 任务轮询、sqp_/squ_ 令牌处理）
-    sdlc-cycle.md         5 阶段 SDLC 自动化
-    knowledge-graph.md    重新生成 .claude 知识图谱 + 断链检查
-  hooks/
-    pre-commit.sh         pre-commit 门禁骨架（技术栈片段的接入点）
-    post-edit-format.sh   PostToolUse(Edit|Write) → 自动格式化
-    post-test-notify.sh   PostToolUse(Bash, *test*) → 终端通知
-    stop-memory-remind.sh Stop 钩子 → 每会话一次的记忆提醒
-    cc-check.py            PostToolUse(Bash, git commit) → CC > 15 时告警
-  memory/
-    MEMORY.md              auto-memory 索引（SSOT）
-    README.md               记忆类型/使用规则
-  rules/
-    common.md               P0/P1/P2 优先级分级 + 通用工作流（始终加载）
-    security.md              密钥/认证 P0 + 锁定/管理员初始化规则（按路径作用域）
-    testing.md               每功能一测试、mock 优先的单元测试、用户视角断言
-    data.md                  数据脚本规则 —— 禁止批量暂存、显式指定编码
-    README.md                按路径作用域加载 + 规则编写原则
-  skills/
-    skill-evolve/            自我改进元 skill（"Learned warnings" 模式）
-    status/                   多技术栈状态检查
-    review/                   code-reviewer + security-audit 封装
-    memory-factcheck/         记忆事实核查 —— 对照代码/DB/issue 验证并修正过期内容
-    security-precheck/        审计前安全排查 → 拆分 issue → 并行修复
-    docs-sync/                文档现行化 — 逐条主张核对 + 多语言配对文件同步
-  workflows/             （不会自动加载 — 需显式调用）
-    rules-audit.js           存储式 Workflow 示例 —— 扫描/验证/修复，合并由人工把关
-  scripts/               （不会自动加载 — 需显式调用）
-    knowledge_graph.py       .claude 生态图谱 + --check 断链门禁
-  settings.json               钩子接线 + 默认 deny 规则
-AGENTS.md                 项目大脑 —— 规则 SSOT（P0/P1/P2 + 工作流）
-CLAUDE.md                 @AGENTS.md + 记忆索引 import（Claude Code）
-GEMINI.md                 @AGENTS.md + 记忆索引 import（Gemini CLI）
-presets/                  预设片段（复制覆盖模型）
-  forge-github/           GitHub forge —— gh、PR、`Closes #N` 自动关闭
-  forge-gitlab/           GitLab forge —— glab、MR、`Closes #N` 自动关闭（合并后需确认）
-  nextjs/ bun/ ...        各技术栈片段（规则 + pre-commit.partial.sh）
-  lang-en/                英文覆盖层（base/forge-*/stacks/*）—— 见下文 `--lang`
-bin/                      agents-scaffold.sh 引导脚本
-tests/                    引导脚本的 bats 回归测试套件
-```
-
-## 技术栈预设
-
-| 预设 | 规则文件 | pre-commit 门禁 |
-|--------|-----------|-----------------|
-| `nextjs` | nextjs.md (paths: app/**, components/**) | `tsc --noEmit` |
-| `springboot` | springboot.md (paths: src/main/java/**) | `./gradlew build` |
-| `javaweb` | javaweb.md (paths: src/main/java/**, **/*.jsp) | maven/gradle/ant compile（自动检测） |
-| `bun` | bun.md (paths: **/*.ts) | `bunx tsc --noEmit` |
-| `python` | python.md (paths: **/*.py) | `ruff check` + `mypy` |
-| `go` | go.md (paths: **/*.go) | `go build ./...` + `vet` + `golangci-lint` |
-| `rust` | rust.md (paths: src/**/*.rs, **/*.rs) | `cargo check` + `clippy` |
-| `android` | android.md (paths: **/*.kt) | `./gradlew ktlintCheck detekt` |
-| `flutter` | flutter.md (paths: **/*.dart, pubspec.yaml) | `dart format` + `flutter analyze` + `test` |
-| `ops` | ops.md (paths: Dockerfile, docker-compose*, quadlet/**, ansible/**) | — |
-
-## Forge 预设（`--forge`）
-
-注入与你所用 forge 匹配的 issue/PR 工作流。在技术栈预设之前合并。
-
-| 预设 | CLI | PR/MR | issue 关闭 |
-|--------|-----|-------|-------------|
-| `github`（默认） | `gh` | PR | 合并时通过 `Closes #N` **自动关闭** |
-| `gitlab` | `glab` | MR | `Closes #N` 自动关闭有效 —— 合并后需确认，仍处于 open 时才手动关闭 |
-
-注入的文件：`.claude/rules/forge.md`（始终加载），以及
-`.claude/commands/fix-issue.md` 和 `sdlc-cycle.md` 的 forge 变体（覆盖基础版本）。
-基础文件保持 forge 中立（"issue / PR·MR"）。
-
-## 挑选需求打磨工具
-
-实现之前打磨需求的手段有三种，**性质各不相同，按任务挑选**。内置的只有 `grill-me`，另外两个需单独安装。
-
-| | `grill-me` | superpowers | Ouroboros |
-|---|---|---|---|
-| **范围** | 仅拷问 | 覆盖整个工作流 | 拷问 → 规格 → 执行 → 评估 循环 |
-| **状态** | 止于对话之内 | 对话 + 文件产物 | 由 MCP 服务器持久管理 |
-| **重量** | 轻 | 中 | 重 — 每个问题都会 fanout 子代理 |
-| **安装** | **内置**（`.claude/skills/grill-me/`） | 插件 [obra/superpowers](https://github.com/obra/superpowers) | 市场 [Q00/ouroboros](https://github.com/Q00/ouroboros)（附带 MCP 服务器） |
-
-**选择标准**
-
-- 方向已定的功能，想找出规格中的漏洞 → **`grill-me`**。无需安装，一轮对话即可。
-- 一张白纸需要发散再收敛，并留下文档产物 → **superpowers 的 `brainstorming`**。
-- 需求模糊的大型工作，需要**先规格化，再以循环方式执行与评估** → **Ouroboros**。会话中断后状态仍在，但 token 成本三者中最高。
-
-按重量逐级升级，且**只向上走** — 轻量方案够用的任务上动用 Ouroboros 只会推高成本。三者即便都已安装也不会自动触发，由使用者按任务选定。
-
-## Harness（`--harness`）
-
-| 取值 | 目标 | 行为 |
-|---|---|---|
-| `claude`（默认） | Claude Code | 完整安装 — 含 settings.json 钩子绑定、子代理、斜杠命令、workflows |
-| `codex` | Codex 及其他 AGENTS.md harness | 仅安装与 harness 无关的层（AGENTS.md、rules、skills、hooks、memory），移除 Claude 专用层 |
-| `all` | 混合团队 | 完整安装 |
-
-**保障分为两级（#21）** — 不是"支持/不支持"的二分法。
-
-| 级别 | 成立的内容 | 适用 harness |
-|---|---|---|
-| **baseline** | `AGENTS.md` 正文中的 P0/P1（含所选技术栈的 P0）+ **真正的 `.git/hooks/pre-commit` 门禁** + CI | **全部 harness，与 `--harness` 取值无关。** 无论 harness 读取什么，也无论是否由人在终端直接提交，门禁都会生效 |
-| **full** | baseline + 该 harness 的原生层（子代理、skills、斜杠命令、按路径的条件加载、lifecycle 钩子） | 仅限适配器经过实测验证的 harness |
-
-git 钩子**与 harness 无关，始终接入**（#21）。Claude Code 的 `PreToolUse` 钩子只在该会话通过 Bash 工具提交时触发，因此它属于早期反馈层而非强制线 — 决定性的强制线放在 harness 之外（`.git/hooks` + CI）。已存在的 `.git/hooks/pre-commit` 不会被覆盖，只会给出警告。
-
-所选技术栈的 P0 会**直接插入 `AGENTS.md` 正文**，不依赖 `.claude/rules/` 引用链接，因此在不加载 `.claude/` 的 harness 上同样可达。未选择的技术栈不会被插入（Codex 指令合计默认上限为 32KiB — 以避免 context flooding）。
-
-### 实测验证（2026-08-22）
-
-| Harness | 实测版本 | baseline | full 层已确认 / 未确认的内容 |
-|---|---|---|---|
-| Claude Code | 2.1.239 | 成立 | `.claude/rules/*.md` 的 `paths:` 条件加载、子代理、skills、`settings.json` 钩子 — 均已对照[官方文档](https://code.claude.com/docs/en/memory.md)确认 |
-| Codex | codex-cli 0.149.0 | 成立 | 已实测 `AGENTS.md` 自动加载与依据 P0 拒绝 `.env`。**skills 不会被发现**（见下） |
-| Antigravity | agy **1.1.18**（未重测） | 成立 | 1.1.17 上实测 **headless（`-p`）不加载规则** — 原因未查明。1.1.18 与交互模式均未重测 |
-
-Codex（codex-cli 0.149.0）会自动加载 `codex` 模式产物中的 AGENTS.md，正确回答了规则分级，并**依据 P0 规则主动拒绝了提交 `.env` 的指令**（第一道防线）。即使模型执意尝试，git 钩子也会以 exit 2 拦截（第二道防线，已有测试覆盖）。
-
-**已知缺口 — Codex 的 skills 不会被自动发现。** Codex 发现仓库 skills 的路径是 `.agents/skills`，而当前 `--harness codex` 仍将其留在 `.claude/skills`。规则层（`AGENTS.md`）可用，skills 层不可用 — 这属于 baseline 而非 full。
-
-另有两项 Codex 约束影响设计：
-
-- **指令合计默认上限 32KiB**（`project_doc_max_bytes`），因此只把所选技术栈的 P0 内联进 `AGENTS.md`（`--stack javaweb` 实测 6,869 B — 占上限的 21%）。
-- **`.codex/` 层仅在项目受信任时加载。** 生成文件并不等于生效，因此决定性的强制线放在 `.git/hooks` + CI。
-
-## 语言（`--lang`）
-
-基础目录树（agents、rules、skills、commands、`AGENTS.md`、钩子/settings
-消息）**默认为韩语**（#36 反转——韩语是事实来源，英语是翻译出的覆盖层）。
-`--lang en` 会把英文翻译叠加在最上层，且最后应用——在基础复制、forge 预设、
-技术栈预设之后——用 `presets/lang-en/base` +
-`presets/lang-en/forge-<forge>` + `presets/lang-en/stacks/<stack>` 的内容
-覆盖同名文件。
-
-```bash
-agents-scaffold/bin/agents-scaffold.sh /path/to/new-repo --lang en --forge github --stack bun
-```
-
-`.claude/hooks/pre-commit.sh` 永远不会被 `--lang` 覆盖（它是技术栈片段
-拼接进去的文件——消息只有单一语言，代码不受语言影响）。`--update`
-只刷新韩语基础文件；若需要重新应用英文覆盖层，请在其后再带
-`--lang en` 运行一次。
-
-## Usage 1 — 脚本
-
-```bash
-git clone https://github.com/leeyudok/agents-scaffold.git
-# --forge 默认为 github；GitLab 仓库请用 --forge gitlab
-agents-scaffold/bin/agents-scaffold.sh /path/to/new-repo --forge github --stack nextjs,bun --name my-app
-```
-
-省略 `--forge`/`--stack`/`--name` 即进入交互模式——脚本会依次询问
-（forge 默认为 github）。
-
-### 选项
-
-| 选项 | 说明 |
+| 文档 | 内容 |
 |---|---|
-| `<target-dir>` | 目标目录。默认 `.` |
-| `--forge <forge>` | `github`（默认）或 `gitlab` |
-| `--lang <lang>` | `ko`（默认）或 `en` |
-| `--stack <list>` | 逗号分隔的技术栈预设列表。省略时进入交互式提问 |
-| `--name <name>` | `{{PROJECT_NAME}}` 的替换值。默认 = 目标目录名 |
-| `--yes` | 跳过交互式提问（非交互模式） |
-| `--update` | 刷新已引导项目的基础文件（见下文） |
-
-### 远程一键安装（无需 clone）
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/leeyudok/agents-scaffold/main/bin/agents-scaffold.sh | bash -s -- --stack nextjs --yes
-```
-
-当脚本检测到自己并非从本地检出运行时（例如管道执行），会将
-`AGENTS_SCAFFOLD_REPO` 的 tarball（默认：
-`github.com/leeyudok/agents-scaffold`，可通过环境变量覆盖）下载到临时目录，
-并将其作为模板来源。用 `AGENTS_SCAFFOLD_REF` 固定分支/标签
-（默认 `main`）。
-
-### 更新基础文件 — `--update`
-
-将最新的基础文件（`.claude/`、`AGENTS.md`、`CLAUDE.md`、
-`GEMINI.md`）应用到已完成引导的项目。
-
-```bash
-agents-scaffold/bin/agents-scaffold.sh --update /path/to/existing-repo
-```
-
-- `.claude/hooks/pre-commit.sh` 始终被跳过——技术栈片段已被拼接
-  进去，需要手动合并。
-- 其他基础文件内容相同时跳过；有差异时保留现有文件，新版本写为
-  `<file>.new`（占位符替换同样作用于 `.new` 文件）。
-- 结束时打印新增 / 待更新 / 跳过 / 未变更文件的汇总——用 `diff`
-  查看 `.new` 文件后手动应用。
-
-## Usage 2 — GitLab 模板
-
-若想在创建新项目时自动应用这套配置，
-请参阅 **[docs/GITLAB_TEMPLATE.md](docs/GITLAB_TEMPLATE.md)**。
-
-> 注意：该工作流假定使用自托管 GitLab 实例。在 **GitLab CE** 上，
-> 原生的自定义项目模板属于 Premium 功能、不可用——
-> 请改用 **Import by URL + `bin/agents-scaffold.sh`** 或**仅用脚本**。
-> 创建/导入后运行一次 `bin/agents-scaffold.sh .`，即可应用所选
-> 技术栈、替换占位符，并自清理 `bin/`/`presets/`/`docs/superpowers/`。
-
-## 占位符替换
-
-| 令牌 | 值 |
-|---|---|
-| `{{PROJECT_NAME}}` | `--name` 的值，或目标目录名 |
-| `{{JAVA_VERSION}}` | `1.8`（springboot 预设默认值） |
-
-## 关键模式
-
-- **P0/P1/P2 优先级分级**：定义于 `common.md` + `AGENTS.md`。P0 = 安全/密钥/数据破坏，无一例外。
-- **SDLC 角色分离**：developer/tester/verifier 三个 agent + `/sdlc-cycle` 自动化命令。
-- **skill-evolve / agent-evolve**：从错误中提炼 "Learned warnings" 并追加的自我改进模式。`skill-evolve` 作用于 `.claude/skills/*.md`，`agent-evolve` 作用于 `.claude/agents/*.md`。
-- **Memory SSOT**：`.claude/memory/`（不使用系统默认路径）。类型前缀：`project_`/`feedback_`/`reference_`/`user_`。
-- **按路径作用域加载的规则**：frontmatter `paths:` 使规则仅在处理匹配文件时自动加载。
-- **多 agent 隔离**：并行 subagent 可能同时触碰同一文件时，使用 `isolation: "worktree"`。
+| [docs/OPTIONS.zh.md](docs/OPTIONS.zh.md) | 全部选项 — 10 种技术栈预设、`--forge`、`--harness`、`--lang`、用法、占位符替换、需求打磨工具的挑选 |
+| [docs/INTERNALS.zh.md](docs/INTERNALS.zh.md) | 内部结构 — 生成的完整 `.claude/` 目录树、关键模式 |
+| [CONTRIBUTING.md](CONTRIBUTING.md) | 贡献指南 |
 
 ## 贡献
 

--- a/docs/INTERNALS.en.md
+++ b/docs/INTERNALS.en.md
@@ -1,0 +1,66 @@
+# agents-scaffold — internals
+
+The generated `.claude/` tree and the design patterns behind it. Start at the [README](../README.en.md).
+
+## What's inside
+
+```
+.claude/
+  agents/
+    security-audit.md   12-item P0/P1 security grep scan
+    db-migration.md      DDL safety check + rollback SQL generation
+    sdlc-developer.md    minimal-scope implementation agent (SDLC role split)
+    sdlc-tester.md        AC/TC test-writing agent
+    sdlc-verifier.md      pipeline execution + report agent
+    agent-evolve.md       self-improving meta agent — refines agents/*.md from run feedback
+  commands/              (legacy on Claude Code — slash commands merged into skills)
+    sonar.md             SonarQube analysis (CE task polling, sqp_/squ_ token handling)
+    sdlc-cycle.md         5-stage SDLC automation
+    knowledge-graph.md    regenerate the .claude knowledge graph + broken-link check
+  hooks/
+    pre-commit.sh         pre-commit gate skeleton (stack partial entry point)
+    post-edit-format.sh   PostToolUse(Edit|Write) → auto-format
+    post-test-notify.sh   PostToolUse(Bash, *test*) → terminal notification
+    stop-memory-remind.sh Stop hook → once-per-session memory reminder
+    cc-check.py            PostToolUse(Bash, git commit) → warn if CC > 15
+  memory/
+    MEMORY.md              auto-memory index (SSOT)
+    README.md               memory type/usage rules
+  rules/
+    common.md               P0/P1/P2 priority tiers + common workflow (always loaded)
+    security.md              secrets/auth P0 + lockout/admin-seeding rules (paths-scoped)
+    testing.md               test-per-feature, mock-first units, user-perspective assertions
+    data.md                  data-script rules — no bulk staging, explicit encodings
+    README.md                paths-scoped loading + rule-authoring principles
+  skills/
+    skill-evolve/            self-improving meta skill ("Learned warnings" pattern)
+    status/                   multi-stack status check
+    review/                   code-reviewer + security-audit wrapper
+    memory-factcheck/         memory fact-check — verify claims against code/DB/issues, correct stale
+    security-precheck/        pre-audit security sweep → issues → parallel fixes
+    docs-sync/                doc currency — claim-by-claim verification + parallel-language sync
+  workflows/             (not auto-loaded — invoked explicitly)
+    rules-audit.js           stored Workflow example — scan/verify/repair with human merge gate
+  scripts/               (not auto-loaded — invoked explicitly)
+    knowledge_graph.py       .claude ecosystem graph + --check broken-link gate
+  settings.json               hook wiring + default deny rules
+AGENTS.md                 project brain — rule SSOT (P0/P1/P2 + workflow)
+CLAUDE.md                 @AGENTS.md + memory-index import (Claude Code)
+GEMINI.md                 @AGENTS.md + memory-index import (Gemini CLI)
+presets/                  preset fragments (copy-overwrite model)
+  forge-github/           GitHub forge — gh, PRs, `Closes #N` auto-close
+  forge-gitlab/           GitLab forge — glab, MRs, `Closes #N` auto-close (verify after merge)
+  nextjs/ bun/ ...        per-stack fragments (rules + pre-commit.partial.sh + AGENTS.partial.md)
+  lang-en/                English overlay (base/forge-*/stacks/*) — see `--lang` below
+bin/                      agents-scaffold.sh bootstrap script
+tests/                    bats regression suite for the bootstrap script
+```
+
+## Key patterns
+
+- **P0/P1/P2 priority tiers**: defined in `common.md` + `AGENTS.md`. P0 = security/secrets/data destruction, no exceptions.
+- **SDLC role split**: developer/tester/verifier agents + the `/sdlc-cycle` automation command.
+- **skill-evolve / agent-evolve**: a self-improvement pattern that appends "Learned warnings" from mistakes. `skill-evolve` targets `.claude/skills/*.md`, `agent-evolve` targets `.claude/agents/*.md`.
+- **Memory SSOT**: `.claude/memory/` (the system default path is not used). Type prefixes: `project_`/`feedback_`/`reference_`/`user_`.
+- **Paths-scoped rules**: frontmatter `paths:` auto-loads a rule only while working on matching files.
+- **Multi-agent isolation**: when parallel subagents may touch the same file concurrently, use `isolation: "worktree"`.

--- a/docs/INTERNALS.ja.md
+++ b/docs/INTERNALS.ja.md
@@ -1,0 +1,66 @@
+# agents-scaffold — 内部構造
+
+生成される `.claude/` ツリーと設計パターン。概要は [README](../README.ja.md) を参照。
+
+## 中身
+
+```
+.claude/
+  agents/
+    security-audit.md   12項目の P0/P1 セキュリティ grep スキャン
+    db-migration.md      DDL 安全性チェック + ロールバック SQL 生成
+    sdlc-developer.md    最小スコープ実装エージェント(SDLC 役割分離)
+    sdlc-tester.md        AC/TC テスト作成エージェント
+    sdlc-verifier.md      パイプライン実行 + レポートエージェント
+    agent-evolve.md       自己改善メタエージェント — 実行フィードバックから agents/*.md を洗練
+  commands/              （Claude Code ではレガシー — スラッシュコマンドは skills に統合）
+    sonar.md             SonarQube 分析(CE タスクポーリング、sqp_/squ_ トークン処理)
+    sdlc-cycle.md         5段階 SDLC 自動化
+    knowledge-graph.md    .claude ナレッジグラフ再生成 + リンク切れチェック
+  hooks/
+    pre-commit.sh         pre-commit ゲートのスケルトン(スタックパーシャルの挿入点)
+    post-edit-format.sh   PostToolUse(Edit|Write) → 自動フォーマット
+    post-test-notify.sh   PostToolUse(Bash, *test*) → ターミナル通知
+    stop-memory-remind.sh Stop フック → セッションごとに1回のメモリリマインダー
+    cc-check.py            PostToolUse(Bash, git commit) → CC > 15 なら警告
+  memory/
+    MEMORY.md              auto-memory インデックス(SSOT)
+    README.md               メモリのタイプ/利用ルール
+  rules/
+    common.md               P0/P1/P2 優先度階層 + 共通ワークフロー(常時ロード)
+    security.md              シークレット/認証 P0 + ロックアウト/管理者シーディング規則(paths スコープ)
+    testing.md               機能ごとにテスト、mock 優先ユニット、ユーザー視点アサーション
+    data.md                  データスクリプト規則 — 一括ステージング禁止、エンコーディング明示
+    README.md                paths スコープロード + ルール作成原則
+  skills/
+    skill-evolve/            自己改善メタスキル(「Learned warnings」パターン)
+    status/                   マルチスタック状態チェック
+    review/                   code-reviewer + security-audit ラッパー
+    memory-factcheck/         メモリのファクトチェック — 主張をコード/DB/イシューと照合し、古いものを修正
+    security-precheck/        監査前セキュリティスイープ → イシュー化 → 並列修正
+    docs-sync/                ドキュメント現行化 — 主張ごとの事実照合 + 多言語ペアの同時更新
+  workflows/             （自動ロードされない — 明示的に呼び出す）
+    rules-audit.js           保存型 Workflow の例 — scan/verify/repair、マージは人間ゲート
+  scripts/               （自動ロードされない — 明示的に呼び出す）
+    knowledge_graph.py       .claude エコシステムグラフ + --check リンク切れゲート
+  settings.json               フック配線 + デフォルト deny ルール
+AGENTS.md                 プロジェクトの頭脳 — ルール SSOT(P0/P1/P2 + ワークフロー)
+CLAUDE.md                 @AGENTS.md + メモリインデックスの import (Claude Code)
+GEMINI.md                 @AGENTS.md + メモリインデックスの import (Gemini CLI)
+presets/                  プリセット断片(コピー上書きモデル)
+  forge-github/           GitHub forge — gh、PR、`Closes #N` 自動クローズ
+  forge-gitlab/           GitLab forge — glab、MR、`Closes #N` 自動クローズ(マージ後に確認)
+  nextjs/ bun/ ...        スタック別断片(rules + pre-commit.partial.sh + AGENTS.partial.md)
+  lang-en/                英語オーバーレイ(base/forge-*/stacks/*)— 後述の `--lang` を参照
+bin/                      agents-scaffold.sh ブートストラップスクリプト
+tests/                    ブートストラップスクリプト用 bats リグレッションスイート
+```
+
+## 主要パターン
+
+- **P0/P1/P2 優先度階層**: `common.md` + `AGENTS.md` で定義。P0 = セキュリティ/シークレット/データ破壊、例外なし。
+- **SDLC 役割分離**: developer/tester/verifier エージェント + `/sdlc-cycle` 自動化コマンド。
+- **skill-evolve / agent-evolve**: ミスから「Learned warnings」を追記する自己改善パターン。`skill-evolve` は `.claude/skills/*.md`、`agent-evolve` は `.claude/agents/*.md` が対象。
+- **メモリ SSOT**: `.claude/memory/`(システムデフォルトパスは使用しない)。タイプ接頭辞: `project_`/`feedback_`/`reference_`/`user_`。
+- **paths スコープのルール**: frontmatter の `paths:` により、マッチするファイルの作業中のみルールを自動ロード。
+- **マルチエージェント分離**: 並列サブエージェントが同一ファイルを同時に触る可能性がある場合は `isolation: "worktree"` を使用。

--- a/docs/INTERNALS.md
+++ b/docs/INTERNALS.md
@@ -1,0 +1,65 @@
+# agents-scaffold — 내부 구조
+
+생성되는 `.claude/` 트리와 설계 패턴. 개요는 [README](../README.md) 참조.
+
+## 무엇이 들어있나
+
+```
+.claude/
+  agents/
+    security-audit.md   12-item P0/P1 보안 그레프 스캔
+    db-migration.md     DDL 안전성 검증 + 롤백 SQL 생성
+    sdlc-developer.md   최소 범위 구현 에이전트 (SDLC 역할 분리)
+    sdlc-tester.md      AC/TC 테스트 작성 에이전트
+    sdlc-verifier.md    파이프라인 실행·리포트 에이전트
+    agent-evolve.md     자기개선 메타 에이전트 — 실행 피드백으로 agents/*.md 자동 개선
+  commands/            (Claude Code 에서는 레거시 — 슬래시 커맨드가 skills 로 통합됨)
+    sonar.md            SonarQube 분석 (CE task 폴링, sqp_/squ_ 구분)
+    sdlc-cycle.md       5단계 SDLC 자동화
+    knowledge-graph.md  .claude 지식 그래프 재생성 + 깨진 링크 체크
+  hooks/
+    pre-commit.sh       pre-commit 게이트 골격 (스택 partial 진입점)
+    post-edit-format.sh PostToolUse(Edit|Write) → 자동 포맷
+    post-test-notify.sh PostToolUse(Bash, *test*) → 터미널 알림
+    stop-memory-remind.sh Stop hook → 세션-once 메모리 리마인드
+    cc-check.py         PostToolUse(Bash, git commit) → CC > 15 경고
+  memory/
+    MEMORY.md           auto-memory 인덱스 (SSOT)
+    README.md           메모리 타입·운용 규칙
+  rules/
+    common.md           P0/P1/P2 우선순위 체계 + 공통 워크플로 (항상 로드)
+    security.md         시크릿/인증 P0 + 록아웃·관리자 주입 규칙 (paths 스코프)
+    testing.md          기능당 1테스트, mock 단위 우선, 사용자 관점 어설션
+    data.md             데이터 스크립트 규칙 — 대량 스테이징 금지, 인코딩 명시
+    README.md           paths 스코프 로드 + 룰 작성 원칙
+  skills/
+    skill-evolve/       자기개선 메타 스킬 (Learned warnings 패턴)
+    status/             멀티스택 상태 체크
+    review/             code-reviewer + security-audit 래퍼
+    memory-factcheck/   메모리 사실 검증 — 코드·DB·이슈 대조로 stale 정정
+    security-precheck/  감사 대비 보안 사전점검 → 이슈 → 병렬 수정
+    docs-sync/          문서 현행화 — 주장별 사실 대조 + 다국어 짝 파일 동시 갱신
+  workflows/            (자동 로드 아님 — 명시 호출로만 실행)
+    rules-audit.js      저장형 Workflow 예제 — 스캔/검증/수정, 머지는 사람 게이트
+  scripts/              (자동 로드 아님 — 명시 호출로만 실행)
+    knowledge_graph.py  .claude 생태계 그래프 + --check 깨진 링크 게이트
+  settings.json         hooks 와이어링 + deny 기본값
+AGENTS.md               프로젝트 브레인 — 규칙 SSOT (P0/P1/P2 + 워크플로)
+CLAUDE.md               @AGENTS.md + 메모리 인덱스 import (Claude Code)
+GEMINI.md               @AGENTS.md + 메모리 인덱스 import (Gemini CLI)
+presets/                프리셋 조각 (복사 덮어쓰기 방식)
+  forge-github/         GitHub forge — gh, PR, `Closes #N` 자동 클로즈
+  forge-gitlab/         GitLab forge — glab, MR, `Closes #N` 자동 클로즈(머지 후 확인)
+  nextjs/ bun/ ...      스택별 조각 (rules + pre-commit.partial.sh + AGENTS.partial.md)
+  lang-en/              영어 오버레이 (base/forge-*/stacks/*) — 아래 `--lang` 참조
+bin/                    agents-scaffold.sh 부트스트랩 스크립트
+```
+
+## 주요 패턴
+
+- **P0/P1/P2 우선순위**: `common.md` + `AGENTS.md` 에 정의. P0 = 보안/시크릿/데이터 파괴, 예외 없음.
+- **SDLC 역할 분리**: developer/tester/verifier 에이전트 + `/sdlc-cycle` 자동화 명령.
+- **skill-evolve / agent-evolve**: 실수에서 "Learned warnings" 추가하는 자기개선 패턴. skill-evolve는 `.claude/skills/*.md`, agent-evolve는 `.claude/agents/*.md` 대상.
+- **메모리 SSOT**: `.claude/memory/`(시스템 기본 경로 미사용). 타입접두 `project_`/`feedback_`/`reference_`/`user_`.
+- **paths 스코프 룰**: frontmatter `paths:` 로 해당 파일 작업 시에만 자동 로드.
+- **멀티에이전트 격리**: 병렬 서브에이전트 파일 동시수정 → `isolation: "worktree"`.

--- a/docs/INTERNALS.zh.md
+++ b/docs/INTERNALS.zh.md
@@ -1,0 +1,66 @@
+# agents-scaffold — 内部结构
+
+生成的 `.claude/` 目录树与设计模式。概览请见 [README](../README.zh.md)。
+
+## 内含什么
+
+```
+.claude/
+  agents/
+    security-audit.md   12 项 P0/P1 安全 grep 扫描
+    db-migration.md      DDL 安全检查 + 回滚 SQL 生成
+    sdlc-developer.md    最小范围实现 agent（SDLC 角色分离）
+    sdlc-tester.md        AC/TC 测试编写 agent
+    sdlc-verifier.md      流水线执行 + 报告 agent
+    agent-evolve.md       自我改进元 agent —— 根据运行反馈打磨 agents/*.md
+  commands/              （在 Claude Code 上属遗留 — 斜杠命令已并入 skills）
+    sonar.md             SonarQube 分析（CE 任务轮询、sqp_/squ_ 令牌处理）
+    sdlc-cycle.md         5 阶段 SDLC 自动化
+    knowledge-graph.md    重新生成 .claude 知识图谱 + 断链检查
+  hooks/
+    pre-commit.sh         pre-commit 门禁骨架（技术栈片段的接入点）
+    post-edit-format.sh   PostToolUse(Edit|Write) → 自动格式化
+    post-test-notify.sh   PostToolUse(Bash, *test*) → 终端通知
+    stop-memory-remind.sh Stop 钩子 → 每会话一次的记忆提醒
+    cc-check.py            PostToolUse(Bash, git commit) → CC > 15 时告警
+  memory/
+    MEMORY.md              auto-memory 索引（SSOT）
+    README.md               记忆类型/使用规则
+  rules/
+    common.md               P0/P1/P2 优先级分级 + 通用工作流（始终加载）
+    security.md              密钥/认证 P0 + 锁定/管理员初始化规则（按路径作用域）
+    testing.md               每功能一测试、mock 优先的单元测试、用户视角断言
+    data.md                  数据脚本规则 —— 禁止批量暂存、显式指定编码
+    README.md                按路径作用域加载 + 规则编写原则
+  skills/
+    skill-evolve/            自我改进元 skill（"Learned warnings" 模式）
+    status/                   多技术栈状态检查
+    review/                   code-reviewer + security-audit 封装
+    memory-factcheck/         记忆事实核查 —— 对照代码/DB/issue 验证并修正过期内容
+    security-precheck/        审计前安全排查 → 拆分 issue → 并行修复
+    docs-sync/                文档现行化 — 逐条主张核对 + 多语言配对文件同步
+  workflows/             （不会自动加载 — 需显式调用）
+    rules-audit.js           存储式 Workflow 示例 —— 扫描/验证/修复，合并由人工把关
+  scripts/               （不会自动加载 — 需显式调用）
+    knowledge_graph.py       .claude 生态图谱 + --check 断链门禁
+  settings.json               钩子接线 + 默认 deny 规则
+AGENTS.md                 项目大脑 —— 规则 SSOT（P0/P1/P2 + 工作流）
+CLAUDE.md                 @AGENTS.md + 记忆索引 import（Claude Code）
+GEMINI.md                 @AGENTS.md + 记忆索引 import（Gemini CLI）
+presets/                  预设片段（复制覆盖模型）
+  forge-github/           GitHub forge —— gh、PR、`Closes #N` 自动关闭
+  forge-gitlab/           GitLab forge —— glab、MR、`Closes #N` 自动关闭（合并后需确认）
+  nextjs/ bun/ ...        各技术栈片段（规则 + pre-commit.partial.sh）
+  lang-en/                英文覆盖层（base/forge-*/stacks/*）—— 见下文 `--lang`
+bin/                      agents-scaffold.sh 引导脚本
+tests/                    引导脚本的 bats 回归测试套件
+```
+
+## 关键模式
+
+- **P0/P1/P2 优先级分级**：定义于 `common.md` + `AGENTS.md`。P0 = 安全/密钥/数据破坏，无一例外。
+- **SDLC 角色分离**：developer/tester/verifier 三个 agent + `/sdlc-cycle` 自动化命令。
+- **skill-evolve / agent-evolve**：从错误中提炼 "Learned warnings" 并追加的自我改进模式。`skill-evolve` 作用于 `.claude/skills/*.md`，`agent-evolve` 作用于 `.claude/agents/*.md`。
+- **Memory SSOT**：`.claude/memory/`（不使用系统默认路径）。类型前缀：`project_`/`feedback_`/`reference_`/`user_`。
+- **按路径作用域加载的规则**：frontmatter `paths:` 使规则仅在处理匹配文件时自动加载。
+- **多 agent 隔离**：并行 subagent 可能同时触碰同一文件时，使用 `isolation: "worktree"`。

--- a/docs/OPTIONS.en.md
+++ b/docs/OPTIONS.en.md
@@ -1,0 +1,186 @@
+# agents-scaffold — all options
+
+Every option of `bin/agents-scaffold.sh`. Start at the [README](../README.en.md).
+
+## Stack presets
+
+| Preset | Rule file | pre-commit gate |
+|--------|-----------|-----------------|
+| `nextjs` | nextjs.md (paths: app/**, components/**) | `tsc --noEmit` |
+| `springboot` | springboot.md (paths: src/main/java/**) | `./gradlew build` |
+| `javaweb` | javaweb.md (paths: src/main/java/**, **/*.jsp) | maven/gradle/ant compile (auto-detect) |
+| `bun` | bun.md (paths: **/*.ts) | `bunx tsc --noEmit` |
+| `python` | python.md (paths: **/*.py) | `ruff check` + `mypy` |
+| `go` | go.md (paths: **/*.go) | `go build ./...` + `vet` + `golangci-lint` |
+| `rust` | rust.md (paths: src/**/*.rs, **/*.rs) | `cargo check` + `clippy` |
+| `android` | android.md (paths: **/*.kt) | `./gradlew ktlintCheck detekt` |
+| `flutter` | flutter.md (paths: **/*.dart, pubspec.yaml) | `dart format` + `flutter analyze` + `test` |
+| `ops` | ops.md (paths: Dockerfile, docker-compose*, quadlet/**, ansible/**) | — |
+
+## Forge presets (`--forge`)
+
+Injects the issue/PR workflow for your forge. Merged before stack presets.
+
+| Preset | CLI | PR/MR | Issue close |
+|--------|-----|-------|-------------|
+| `github` (default) | `gh` | PR | **auto-closed** on merge via `Closes #N` |
+| `gitlab` | `glab` | MR | `Closes #N` auto-close works — verify post-merge, manual only if still open |
+
+Injected files: `.claude/rules/forge.md` (always loaded) plus forge variants of
+`.claude/commands/fix-issue.md` and `sdlc-cycle.md` (overwrite the base). Base
+files stay forge-neutral ("issue / PR·MR").
+
+## Picking a requirements-hardening tool
+
+Three tools harden requirements before implementation, and **they differ enough that you pick per
+task.** Only `grill-me` is bundled; the other two install separately.
+
+| | `grill-me` | superpowers | Ouroboros |
+|---|---|---|---|
+| **Scope** | interrogation only | the whole workflow | interrogate → spec → run → evaluate loop |
+| **State** | stays in the conversation | conversation + file artifacts | an MCP server keeps it persistently |
+| **Weight** | light | medium | heavy — fans out a subagent per question |
+| **Install** | **bundled** (`.claude/skills/grill-me/`) | plugin, [obra/superpowers](https://github.com/obra/superpowers) | marketplace, [Q00/ouroboros](https://github.com/Q00/ouroboros) (ships an MCP server) |
+
+**How to choose**
+
+- A feature that already has direction, and you want the holes in its spec found → **`grill-me`**.
+  Nothing to install, one conversation and you're done.
+- A blank page you need to diverge and converge on, with a document to keep → **superpowers'
+  `brainstorming`**.
+- A large, vaguely specified job that has to be **turned into a spec and then run and evaluated in
+  a loop** → **Ouroboros**. State survives a dropped session, at the highest token cost of the three.
+
+Escalate by weight, and **only upward** — reaching for Ouroboros where the light option would do
+just costs more. None of them fire automatically, even with all three installed; you pick per task.
+
+## Harness (`--harness`)
+
+| Value | Target | What it does |
+|---|---|---|
+| `claude` (default) | Claude Code | Full install — settings.json hook bindings, subagents, slash commands, workflows |
+| `codex` | Codex and other AGENTS.md harnesses | Installs only the harness-neutral layers (AGENTS.md, rules, skills, hooks, memory) and drops the Claude-only layers |
+| `all` | Mixed teams | Full install |
+
+**Support comes in two tiers (#21)** — not a binary "supported / unsupported".
+
+| Tier | What holds | Which harnesses |
+|---|---|---|
+| **baseline** | The P0/P1 tiers in the `AGENTS.md` body (including the selected stack's P0) + a **real `.git/hooks/pre-commit` gate** + CI | **Every harness, whatever `--harness` you passed.** It holds no matter what the harness reads, and it holds when a human commits straight from the terminal |
+| **full** | baseline + that harness's native layers (subagents, skills, slash commands, path-scoped rule loading, lifecycle hooks) | Only harnesses whose adapter has been measured |
+
+The git hook is **always wired, regardless of harness** (#21). Claude Code's `PreToolUse` hook only fires when that session commits through the Bash tool, so it is an early-feedback layer, not the enforcement line — the deterministic line lives outside the harness (`.git/hooks` + CI). An existing `.git/hooks/pre-commit` is never overwritten; you get a warning instead.
+
+The selected stack's P0 rules are **inlined into the `AGENTS.md` body**, so they do not depend on a `.claude/rules/` reference link and stay reachable on harnesses that never load `.claude/`. Stacks you did not select are not inlined (Codex caps combined instructions at 32KiB by default — this avoids context flooding).
+
+### Verified (2026-08-22)
+
+| Harness | Measured version | baseline | What is / isn't confirmed on the full tier |
+|---|---|---|---|
+| Claude Code | 2.1.239 | holds | `paths:`-scoped loading of `.claude/rules/*.md`, subagents, skills, `settings.json` hooks — all confirmed against the [official docs](https://code.claude.com/docs/en/memory.md) |
+| Codex | codex-cli 0.149.0 | holds | `AGENTS.md` auto-load and a P0-cited `.env` refusal were measured. **Skills are not discovered** (see below) |
+| Antigravity | agy **1.1.18** (not re-measured) | holds | On 1.1.17, **headless (`-p`) measurably did not load rules** — root cause unknown. Neither 1.1.18 nor interactive mode has been re-measured |
+
+Codex (codex-cli 0.149.0) auto-loads the `codex`-mode AGENTS.md, answered the rule tiers
+correctly, and **refused an instruction to commit a `.env`, citing the P0 rule** (first line of
+defense). If a model tries anyway, the git hook blocks it with exit 2 (second line, test-covered).
+
+**Known gap — Codex skills are not auto-discovered.** Codex discovers repository skills under
+`.agents/skills`, but `--harness codex` currently leaves them in `.claude/skills`. The rules layer
+(`AGENTS.md`) works; the skills layer does not — that is baseline, not full.
+
+Two further Codex constraints shape the design:
+
+- **Combined instructions are capped at 32KiB by default** (`project_doc_max_bytes`), which is why
+  only the selected stack's P0 is inlined into `AGENTS.md` (measured 6,869 B with `--stack javaweb`
+  — 21% of the cap).
+- **The `.codex/` layer only loads for a trusted project.** Emitting a file does not guarantee it is
+  active, which is why the deterministic enforcement line lives in `.git/hooks` + CI.
+
+## Language (`--lang`)
+
+The base tree (agents, rules, skills, commands, `AGENTS.md`, hook/settings
+messages) is **Korean by default** (#36 inversion — Korean is the source of
+truth, English is the translated overlay). `--lang en` layers the English
+translation on top, applied last — after the base copy, forge preset, and
+stack presets — so it overrides the same files with `presets/lang-en/base` +
+`presets/lang-en/forge-<forge>` + `presets/lang-en/stacks/<stack>` content.
+
+```bash
+agents-scaffold/bin/agents-scaffold.sh /path/to/new-repo --lang en --forge github --stack bun
+```
+
+`.claude/hooks/pre-commit.sh` is never overlaid by `--lang` (it's the file
+stack partials get spliced into — single-language messages, code unaffected
+by language). `--update` only refreshes the Korean base; re-run with
+`--lang en` on top if you need the English overlay reapplied.
+
+## Usage 1 — script
+
+```bash
+git clone https://github.com/leeyudok/agents-scaffold.git
+# --forge defaults to github; use --forge gitlab for GitLab repos
+agents-scaffold/bin/agents-scaffold.sh /path/to/new-repo --forge github --stack nextjs,bun --name my-app
+```
+
+Omit `--forge`/`--stack`/`--name` to run interactively — the script will prompt
+(forge defaults to github).
+
+### Options
+
+| Option | Description |
+|---|---|
+| `<target-dir>` | Target directory. Default `.` |
+| `--forge <forge>` | `github` (default) or `gitlab` |
+| `--lang <lang>` | `ko` (default) or `en` |
+| `--stack <list>` | Comma-separated stack presets. Prompts interactively when omitted |
+| `--name <name>` | `{{PROJECT_NAME}}` substitution value. Default = target directory name |
+| `--yes` | Skip interactive prompts (non-interactive mode) |
+| `--update` | Refresh base files of an already-bootstrapped project (see below) |
+
+### Remote one-command install (no clone)
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/leeyudok/agents-scaffold/main/bin/agents-scaffold.sh | bash -s -- --stack nextjs --yes
+```
+
+When the script detects it is not running from a local checkout (e.g. piped
+execution), it downloads the `AGENTS_SCAFFOLD_REPO` tarball (default:
+`github.com/leeyudok/agents-scaffold`, override via env) into a temporary directory and
+uses it as the template source. Pin a branch/tag with `AGENTS_SCAFFOLD_REF`
+(default `main`).
+
+### Updating the base — `--update`
+
+Applies the latest base files (`.claude/`, `AGENTS.md`, `CLAUDE.md`,
+`GEMINI.md`) to an already-bootstrapped project.
+
+```bash
+agents-scaffold/bin/agents-scaffold.sh --update /path/to/existing-repo
+```
+
+- `.claude/hooks/pre-commit.sh` is always skipped — stack partials were spliced
+  into it, so it needs manual merging.
+- Other base files are skipped when identical; when they differ, the existing
+  file is preserved and the new version is written as `<file>.new`
+  (placeholder substitution applies to `.new` files too).
+- A summary of added / pending-update / skipped / unchanged files is printed at
+  the end — review `.new` files with `diff` and apply manually.
+
+## Usage 2 — GitLab template
+
+To have this configuration applied automatically when creating a new project,
+see **[docs/GITLAB_TEMPLATE.md](GITLAB_TEMPLATE.md)**.
+
+> Note: this workflow assumes a self-hosted GitLab instance. On **GitLab CE**,
+> native custom project templates are a Premium feature and unavailable —
+> use **Import by URL + `bin/agents-scaffold.sh`** or **the script alone** instead.
+> After creating/importing, run `bin/agents-scaffold.sh .` once to apply the
+> chosen stacks, substitute placeholders, and self-clean `bin/`/`presets/`/`docs/superpowers/`.
+
+## Placeholder substitution
+
+| Token | Value |
+|---|---|
+| `{{PROJECT_NAME}}` | `--name` value, or the target directory name |
+| `{{JAVA_VERSION}}` | `1.8` (springboot preset default) |

--- a/docs/OPTIONS.ja.md
+++ b/docs/OPTIONS.ja.md
@@ -1,0 +1,173 @@
+# agents-scaffold — 全オプション
+
+`bin/agents-scaffold.sh` の全オプション。概要は [README](../README.ja.md) を参照。
+
+## スタックプリセット
+
+| プリセット | ルールファイル | pre-commit ゲート |
+|--------|-----------|-----------------|
+| `nextjs` | nextjs.md (paths: app/**, components/**) | `tsc --noEmit` |
+| `springboot` | springboot.md (paths: src/main/java/**) | `./gradlew build` |
+| `javaweb` | javaweb.md (paths: src/main/java/**, **/*.jsp) | maven/gradle/ant compile (自動検出) |
+| `bun` | bun.md (paths: **/*.ts) | `bunx tsc --noEmit` |
+| `python` | python.md (paths: **/*.py) | `ruff check` + `mypy` |
+| `go` | go.md (paths: **/*.go) | `go build ./...` + `vet` + `golangci-lint` |
+| `rust` | rust.md (paths: src/**/*.rs, **/*.rs) | `cargo check` + `clippy` |
+| `android` | android.md (paths: **/*.kt) | `./gradlew ktlintCheck detekt` |
+| `flutter` | flutter.md (paths: **/*.dart, pubspec.yaml) | `dart format` + `flutter analyze` + `test` |
+| `ops` | ops.md (paths: Dockerfile, docker-compose*, quadlet/**, ansible/**) | — |
+
+## Forge プリセット (`--forge`)
+
+利用する forge のイシュー/PR ワークフローを注入します。スタックプリセットより先にマージされます。
+
+| プリセット | CLI | PR/MR | イシュークローズ |
+|--------|-----|-------|-------------|
+| `github` (デフォルト) | `gh` | PR | `Closes #N` によりマージ時に**自動クローズ** |
+| `gitlab` | `glab` | MR | `Closes #N` の自動クローズは動作する — マージ後に確認し、open のままの場合のみ手動 |
+
+注入されるファイル: `.claude/rules/forge.md`(常時ロード)に加え、
+`.claude/commands/fix-issue.md` と `sdlc-cycle.md` の forge 別バリアント(ベースを上書き)。
+ベースファイルは forge 非依存のまま("issue / PR·MR")です。
+
+## 要件を鍛えるツールの選び方
+
+実装前に要件を鍛える手段は 3 つあり、**性格が異なるのでタスクごとに選びます**。同梱されるのは `grill-me` だけで、残る 2 つは別途インストールします。
+
+| | `grill-me` | superpowers | Ouroboros |
+|---|---|---|---|
+| **範囲** | 尋問のみ | ワークフロー全般 | 尋問 → 仕様 → 実行 → 評価のループ |
+| **状態** | 会話の中で完結 | 会話 + ファイル成果物 | MCP サーバーが永続管理 |
+| **重さ** | 軽い | 中 | 重い — 質問ごとにサブエージェントを fanout |
+| **導入** | **同梱**(`.claude/skills/grill-me/`) | プラグイン [obra/superpowers](https://github.com/obra/superpowers) | マーケットプレイス [Q00/ouroboros](https://github.com/Q00/ouroboros)(MCP サーバー同梱) |
+
+**選ぶ基準**
+
+- 方向性が決まった機能の仕様に穴がないか調べたい → **`grill-me`**。インストール不要、会話 1 回で終わります。
+- 白紙のアイデアを発散・収束させ、成果物(ドキュメント)も残したい → **superpowers の `brainstorming`**。
+- 要件が曖昧な大きめの作業を**仕様化し、実行と評価までループで回したい** → **Ouroboros**。セッションが切れても状態は残りますが、トークンコストは 3 つの中で最大です。
+
+重さの順に上げていき、**下から上へだけ**動かします — 軽い手段で足りる作業に Ouroboros を使ってもコストが増えるだけです。3 つとも入っていても自動では発動せず、タスクごとに使う側が選びます。
+
+## ハーネス (`--harness`)
+
+| 値 | 対象 | 動作 |
+|---|---|---|
+| `claude`（デフォルト） | Claude Code | フルインストール — settings.json のフックバインディング・サブエージェント・スラッシュコマンド・workflows を含む |
+| `codex` | Codex ほか AGENTS.md 対応ハーネス | ハーネス中立の層（AGENTS.md・rules・skills・hooks・memory）のみ導入し、Claude 専用層を除去 |
+| `all` | 混在チーム | フルインストール |
+
+**保証レベルは 2 段階です（#21）** — 「対応している/していない」の二分法ではありません。
+
+| レベル | 成立する内容 | 対象ハーネス |
+|---|---|---|
+| **baseline** | `AGENTS.md` 本文の P0/P1（選択したスタックの P0 を含む）+ **実際の `.git/hooks/pre-commit` ゲート** + CI | **`--harness` の値に関係なく全ハーネス。** ハーネスが何を読むかによらず、人が端末から直接コミットしても同じように掛かります |
+| **full** | baseline + そのハーネスのネイティブ層（サブエージェント・skills・スラッシュコマンド・パススコープのルール読み込み・lifecycle フック） | アダプタが実測検証されたハーネスのみ |
+
+git フックは**ハーネスに関係なく常に配線されます**（#21）。Claude Code の `PreToolUse` フックはそのセッションが Bash ツールでコミットしたときにのみ発火するため、早期フィードバック層であって強制線ではありません — 決定的な強制線はハーネスの外（`.git/hooks` + CI）に置きます。既存の `.git/hooks/pre-commit` は上書きせず、警告のみ出します。
+
+選択したスタックの P0 は **`AGENTS.md` 本文に直接挿入**されます。`.claude/rules/` の参照リンクに依存しないため、`.claude/` を読み込まないハーネスでも到達可能です。選択していないスタックは挿入されません（Codex の指示合計はデフォルト 32KiB 上限 — context flooding を防ぐため）。
+
+### 実測検証（2026-08-22）
+
+| ハーネス | 実測バージョン | baseline | full 層で確認できたこと / できていないこと |
+|---|---|---|---|
+| Claude Code | 2.1.239 | 成立 | `.claude/rules/*.md` の `paths:` 条件付きロード、サブエージェント、skills、`settings.json` フック — いずれも[公式ドキュメント](https://code.claude.com/docs/en/memory.md)で確認 |
+| Codex | codex-cli 0.149.0 | 成立 | `AGENTS.md` の自動ロードと P0 を根拠にした `.env` 拒否を実測。**skills は発見されない**（下記） |
+| Antigravity | agy **1.1.18**（再測定なし） | 成立 | 1.1.17 で **headless（`-p`）がルールを読み込まない**ことを実測 — 原因は未解明。1.1.18 もインタラクティブモードも未検証 |
+
+Codex（codex-cli 0.149.0）は `codex` モード成果物の AGENTS.md を自動で読み込み、ルール階層を正しく回答し、`.env` をコミットせよという指示を **P0 ルールを根拠に自ら拒否**しました（第一の防衛線）。モデルが強行しても git フックが exit 2 でブロックします（第二の防衛線、テスト済み）。
+
+**既知のギャップ — Codex の skills は自動発見されません。** Codex がリポジトリの skills を探す場所は `.agents/skills` ですが、現在の `--harness codex` は `.claude/skills` に残します。ルール層（`AGENTS.md`）は機能しますが skills 層は機能しません — これは full ではなく baseline です。
+
+Codex 側の制約がもう 2 点、設計に効いてきます。
+
+- **指示の合計はデフォルト 32KiB 上限**（`project_doc_max_bytes`）。そのため選択したスタックの P0 のみを `AGENTS.md` にインライン化します（`--stack javaweb` で実測 6,869 B — 上限の 21%）。
+- **`.codex/` レイヤは信頼済みプロジェクトでのみロードされます。** ファイルを生成しても有効化は保証されません。だからこそ決定的な強制線は `.git/hooks` + CI に置きます。
+
+## 言語 (`--lang`)
+
+ベースツリー(エージェント、ルール、スキル、コマンド、`AGENTS.md`、フック/settings の
+メッセージ)は**デフォルトで韓国語**です(#36 での反転 — 韓国語が単一の真実源で、
+英語は翻訳オーバーレイ)。`--lang en` は英訳を最後に重ねます — ベースコピー、
+forge プリセット、スタックプリセットの後に適用されるため、同じファイルを
+`presets/lang-en/base` + `presets/lang-en/forge-<forge>` + `presets/lang-en/stacks/<stack>`
+の内容で上書きします。
+
+```bash
+agents-scaffold/bin/agents-scaffold.sh /path/to/new-repo --lang en --forge github --stack bun
+```
+
+`.claude/hooks/pre-commit.sh` は `--lang` によるオーバーレイの対象外です
+(スタックパーシャルが挿入されるファイルであり、メッセージは単一言語、コードは
+言語の影響を受けません)。`--update` は韓国語のベースのみを更新します。英語
+オーバーレイを再適用したい場合は、その上で `--lang en` を付けて再実行してください。
+
+## Usage 1 — script
+
+```bash
+git clone https://github.com/leeyudok/agents-scaffold.git
+# --forge のデフォルトは github。GitLab リポジトリには --forge gitlab を使う
+agents-scaffold/bin/agents-scaffold.sh /path/to/new-repo --forge github --stack nextjs,bun --name my-app
+```
+
+`--forge`/`--stack`/`--name` を省略すると対話モードで実行され、スクリプトが
+プロンプトを表示します(forge のデフォルトは github)。
+
+### オプション
+
+| オプション | 説明 |
+|---|---|
+| `<target-dir>` | 対象ディレクトリ。デフォルト `.` |
+| `--forge <forge>` | `github`(デフォルト)または `gitlab` |
+| `--lang <lang>` | `ko`(デフォルト)または `en` |
+| `--stack <list>` | カンマ区切りのスタックプリセット。省略時は対話的にプロンプト |
+| `--name <name>` | `{{PROJECT_NAME}}` の置換値。デフォルトは対象ディレクトリ名 |
+| `--yes` | 対話プロンプトをスキップ(非対話モード) |
+| `--update` | ブートストラップ済みプロジェクトのベースファイルを更新(後述) |
+
+### リモートワンコマンドインストール(クローン不要)
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/leeyudok/agents-scaffold/main/bin/agents-scaffold.sh | bash -s -- --stack nextjs --yes
+```
+
+スクリプトはローカルチェックアウトから実行されていないこと(パイプ実行など)を検知すると、
+`AGENTS_SCAFFOLD_REPO` の tarball(デフォルト: `github.com/leeyudok/agents-scaffold`、
+環境変数で上書き可)を一時ディレクトリにダウンロードし、テンプレートソースとして
+使用します。ブランチ/タグの固定は `AGENTS_SCAFFOLD_REF`(デフォルト `main`)で行います。
+
+### ベースの更新 — `--update`
+
+ブートストラップ済みプロジェクトに最新のベースファイル(`.claude/`、`AGENTS.md`、
+`CLAUDE.md`、`GEMINI.md`)を適用します。
+
+```bash
+agents-scaffold/bin/agents-scaffold.sh --update /path/to/existing-repo
+```
+
+- `.claude/hooks/pre-commit.sh` は常にスキップされます — スタックパーシャルが
+  挿入済みのため、手動マージが必要です。
+- その他のベースファイルは、内容が同一ならスキップされます。差分がある場合は
+  既存ファイルを保持し、新バージョンを `<file>.new` として書き出します
+  (プレースホルダー置換は `.new` ファイルにも適用されます)。
+- 最後に追加 / 更新保留 / スキップ / 変更なしのファイルのサマリーが出力されます —
+  `.new` ファイルを `diff` で確認し、手動で適用してください。
+
+## Usage 2 — GitLab テンプレート
+
+新規プロジェクト作成時にこの設定を自動適用するには、
+**[docs/GITLAB_TEMPLATE.md](GITLAB_TEMPLATE.md)** を参照してください。
+
+> 注: このワークフローはセルフホストの GitLab インスタンスを前提とします。**GitLab CE** では
+> ネイティブのカスタムプロジェクトテンプレートは Premium 機能のため利用できません —
+> 代わりに **Import by URL + `bin/agents-scaffold.sh`**、または**スクリプト単体**を使ってください。
+> 作成/インポート後に `bin/agents-scaffold.sh .` を1回実行すると、選択したスタックの適用、
+> プレースホルダー置換、`bin/`/`presets/`/`docs/superpowers/` のセルフクリーンが行われます。
+
+## プレースホルダー置換
+
+| トークン | 値 |
+|---|---|
+| `{{PROJECT_NAME}}` | `--name` の値、または対象ディレクトリ名 |
+| `{{JAVA_VERSION}}` | `1.8`(springboot プリセットのデフォルト) |

--- a/docs/OPTIONS.md
+++ b/docs/OPTIONS.md
@@ -1,0 +1,175 @@
+# agents-scaffold — 전체 옵션
+
+`bin/agents-scaffold.sh` 의 모든 옵션. 개요는 [README](../README.md) 참조.
+
+## 스택 프리셋
+
+| 프리셋 | 룰 파일 | pre-commit 게이트 |
+|--------|---------|-----------------|
+| `nextjs` | nextjs.md (paths: app/**, components/**) | `tsc --noEmit` |
+| `springboot` | springboot.md (paths: src/main/java/**) | `./gradlew build` |
+| `javaweb` | javaweb.md (paths: src/main/java/**, **/*.jsp) | maven/gradle/ant 컴파일 (자동 감지) |
+| `bun` | bun.md (paths: **/*.ts) | `bunx tsc --noEmit` |
+| `python` | python.md (paths: **/*.py) | `ruff check` + `mypy` |
+| `go` | go.md (paths: **/*.go) | `go build ./...` + `vet` + `golangci-lint` |
+| `rust` | rust.md (paths: src/**/*.rs, **/*.rs) | `cargo check` + `clippy` |
+| `android` | android.md (paths: **/*.kt) | `./gradlew ktlintCheck detekt` |
+| `flutter` | flutter.md (paths: **/*.dart, pubspec.yaml) | `dart format` + `flutter analyze` + `test` |
+| `ops` | ops.md (paths: Dockerfile, docker-compose*, quadlet/**, ansible/**) | — |
+
+## Forge 프리셋 (`--forge`)
+
+이슈/PR 워크플로를 forge 별로 주입한다. 스택 프리셋보다 먼저 머지된다.
+
+| 프리셋 | CLI | PR/MR | 이슈 클로즈 |
+|--------|-----|-------|------------|
+| `github` (기본) | `gh` | PR | `Closes #N` 로 머지 시 **자동 클로즈** |
+| `gitlab` | `glab` | MR | `Closes #N` 자동 클로즈 동작 — 머지 후 확인, `opened` 시만 수동 |
+
+주입 파일: `.claude/rules/forge.md`(항상 로드) + `.claude/commands/fix-issue.md`·`sdlc-cycle.md`(forge 변형으로 덮어씀). 베이스 파일은 forge 중립("이슈/PR·MR").
+
+## 요구사항 다지기 도구 고르기
+
+구현 전에 요구사항을 다지는 수단은 세 가지고, **성격이 서로 다르니 작업마다 골라 쓴다.**
+동봉되는 것은 `grill-me` 하나뿐이고 나머지 둘은 별도 설치다.
+
+| | `grill-me` | superpowers | Ouroboros |
+|---|---|---|---|
+| **범위** | 취조만 | 워크플로 전반 | 취조 → 스펙 → 실행 → 평가 루프 |
+| **상태** | 대화 안에서 끝 | 대화 + 파일 산출물 | MCP 서버가 영속 관리 |
+| **무게** | 가벼움 | 중간 | 무거움 — 질문마다 서브에이전트 fanout |
+| **설치** | **동봉** (`.claude/skills/grill-me/`) | 플러그인 [obra/superpowers](https://github.com/obra/superpowers) | 마켓플레이스 [Q00/ouroboros](https://github.com/Q00/ouroboros) (MCP 서버 동반) |
+
+**고르는 기준**
+
+- 이미 방향이 선 기능의 스펙에 구멍이 있는지 → **`grill-me`**. 설치 없이 바로, 대화 한 판으로 끝난다.
+- 백지 아이디어를 발산·수렴하고 산출물(문서)까지 남겨야 함 → **superpowers 의 `brainstorming`**.
+- 요구사항이 모호한 큰 작업을 **스펙화하고 실행·평가까지 루프로 돌려야 함** → **Ouroboros**.
+  세션이 끊겨도 상태가 남는 대신 토큰 비용이 가장 크다.
+
+무게 순으로 올라가되, **아래에서 위로만 간다** — 가벼운 걸로 충분한 작업에 Ouroboros 를
+쓰면 비용만 커진다. 셋 다 설치돼 있어도 자동 발동은 안 하며, 작업마다 사용자가 택일한다.
+
+## 하네스 (`--harness`)
+
+| 값 | 대상 | 하는 일 |
+|---|---|---|
+| `claude` (기본) | Claude Code | 전체 설치 — settings.json 훅 바인딩·서브에이전트·슬래시 커맨드·workflows 포함 |
+| `codex` | Codex 등 AGENTS.md 하네스 | 하네스 중립 계층(AGENTS.md·rules·skills·hooks·memory)만 설치, Claude 전용 계층 제거 |
+| `all` | 혼용 팀 | 전체 설치 |
+
+**보장 수준은 2단이다 (#21)** — "지원한다/안 한다" 이분법이 아니다.
+
+| 수준 | 무엇이 성립하나 | 어느 하네스에서 |
+|---|---|---|
+| **baseline** | `AGENTS.md` 본문의 P0/P1(선택한 스택 P0 포함) + **진짜 `.git/hooks/pre-commit` 게이트** + CI | **전 하네스, `--harness` 값 무관.** 하네스가 무엇을 읽든, 사람이 터미널에서 직접 커밋하든 동일하게 걸린다 |
+| **full** | baseline + 그 하네스의 네이티브 계층(서브에이전트·스킬·슬래시 커맨드·조건부 룰 로딩·lifecycle 훅) | 어댑터가 실측 검증된 하네스만 |
+
+git hook 은 **하네스와 무관하게 항상 배선된다**(#21). Claude Code 의 `PreToolUse` 훅은 그 세션이
+Bash 툴로 커밋할 때만 발동하므로 조기 피드백 계층이지 강제선이 아니다 — 결정적 강제선은
+하네스 밖(`.git/hooks` + CI)에 둔다. 기존 `.git/hooks/pre-commit` 이 있으면 덮어쓰지 않고 경고만 낸다.
+
+선택한 스택의 P0 는 `AGENTS.md` **본문에 직접 삽입**된다 — `.claude/rules/` 참조 링크에 의존하지
+않으므로 `.claude/` 를 로드하지 않는 하네스에서도 도달 가능하다. 선택하지 않은 스택은 삽입되지
+않는다(Codex instruction 합산 기본 한도 32KiB — context flooding 방지).
+
+### 실측 검증 (2026-08-22)
+
+| 하네스 | 실측 버전 | baseline | full 쪽 확인된 것 / 확인 안 된 것 |
+|---|---|---|---|
+| Claude Code | 2.1.239 | 성립 | `.claude/rules/*.md` 의 `paths:` 조건부 로딩, 서브에이전트, skills, `settings.json` 훅 — 전부 [공식 문서](https://code.claude.com/docs/en/memory.md)로 확인 |
+| Codex | codex-cli 0.149.0 | 성립 | `AGENTS.md` 자동 로드·P0 근거 `.env` 거부까지 실측. **스킬은 발견되지 않는다**(아래) |
+| Antigravity | agy **1.1.18** (미재검증) | 성립 | 1.1.17 에서 **headless(`-p`) 규칙 미로드** 실측 — 원인 미규명. 1.1.18 재검증·인터랙티브 모드 모두 미실시 |
+
+Codex(codex-cli 0.149.0)는 `codex` 모드 산출물의 AGENTS.md 를 자동 로드해 룰 티어를 정확히
+답했고, `.env` 커밋 지시를 **P0 규칙을 근거로 스스로 거부**했다(1차 방어). 모델이 시도해도
+git hook 이 exit 2 로 차단한다(2차 방어, 테스트 커버).
+
+**알려진 갭 — Codex 스킬은 자동 발견되지 않는다.** Codex 의 저장소 스킬 발견 경로는
+`.agents/skills` 인데 현재 `--harness codex` 는 `.claude/skills` 를 남긴다. 규칙 계층
+(`AGENTS.md`)은 동작하지만 스킬은 그렇지 않다 — full 이 아니라 baseline 이다.
+
+Codex 쪽 추가 제약 두 가지도 설계에 영향을 준다.
+
+- **instruction 합산 기본 한도 32KiB** (`project_doc_max_bytes`). 그래서 스택 P0 는 선택한
+  스택만 `AGENTS.md` 에 인라인한다 (`--stack javaweb` 기준 실측 6,869 B — 한도의 21%).
+- **`.codex/` 레이어는 프로젝트를 신뢰한 경우에만 로드된다.** 파일을 생성했다고 활성화가
+  보장되지 않는다. 그래서 결정적 강제선을 `.git/hooks` + CI 에 둔다.
+
+## 언어 (`--lang`)
+
+베이스 트리(agents·rules·skills·commands·`AGENTS.md`·훅/settings 메시지)는 **기본이
+한국어다**(#36 반전 — 한국어가 원본, 영어는 번역 오버레이). `--lang en` 을 주면 영어
+번역을 **가장 마지막에** 얹는다 — 베이스 복사 → forge 프리셋 → 스택 프리셋이 끝난 뒤
+`presets/lang-en/base` + `presets/lang-en/forge-<forge>` + `presets/lang-en/stacks/<stack>`
+콘텐츠로 동일 파일을 덮어쓴다.
+
+```bash
+agents-scaffold/bin/agents-scaffold.sh /path/to/new-repo --lang en --forge github --stack bun
+```
+
+`.claude/hooks/pre-commit.sh` 는 `--lang` 오버레이 대상이 아니다(스택 파셜이 삽입되는
+파일이라 언어 단일본 — 코드 동작에는 영향 없음). `--update` 는 한국어 베이스만
+갱신하므로, 영어 오버레이가 필요하면 `--lang en` 으로 다시 실행한다.
+
+## 사용법 1 — 스크립트
+
+```bash
+git clone https://github.com/leeyudok/agents-scaffold.git
+# --forge 기본값 github. GitLab 레포면 --forge gitlab
+agents-scaffold/bin/agents-scaffold.sh /path/to/new-repo --forge github --stack nextjs,bun --name my-app
+```
+
+대화형으로 쓰려면 `--forge`/`--stack`/`--name` 생략 → 프롬프트가 묻는다(forge 기본 github).
+
+### 옵션
+
+| 옵션 | 설명 |
+|---|---|
+| `<target-dir>` | 대상 디렉터리. 기본 `.` |
+| `--forge <forge>` | `github`(기본) 또는 `gitlab` |
+| `--lang <lang>` | `ko`(기본) 또는 `en` |
+| `--stack <목록>` | 쉼표구분 스택 프리셋. 미지정 시 대화형 프롬프트 |
+| `--name <name>` | `{{PROJECT_NAME}}` 치환값. 기본 = 대상 디렉터리명 |
+| `--yes` | 대화형 프롬프트 생략(비대화 모드) |
+| `--update` | 이미 부트스트랩된 프로젝트의 베이스 파일 최신화 (아래 참조) |
+
+### 원격 원커맨드 설치 (clone 불필요)
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/leeyudok/agents-scaffold/main/bin/agents-scaffold.sh | bash -s -- --stack nextjs --yes
+```
+
+로컬에 레포가 없는 상태(파이프 실행)로 감지되면 `AGENTS_SCAFFOLD_REPO`(기본
+`github.com/leeyudok/agents-scaffold`, env 로 오버라이드) tarball 을 임시 디렉터리에 받아 템플릿 소스로 쓴다. 브랜치/태그 지정은
+`AGENTS_SCAFFOLD_REF`(기본 `main`) 로 오버라이드.
+
+### 베이스 갱신 — `--update`
+
+이미 부트스트랩된 프로젝트에 최신 베이스(`.claude/`, `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`)를
+반영한다.
+
+```bash
+agents-scaffold/bin/agents-scaffold.sh --update /path/to/existing-repo
+```
+
+- `.claude/hooks/pre-commit.sh` 는 스택 파셜이 삽입돼 있어 항상 건너뛴다(수동 병합 필요).
+- 그 외 베이스 파일은 대상과 diff 없으면 스킵, 다르면 기존 파일은 그대로 두고 새 버전을
+  `<file>.new` 로 저장한다. `{{PLACEHOLDER}}` 치환은 `.new` 파일에도 적용된다.
+- 실행 끝에 추가/갱신 대기/건너뜀/변경없음 목록을 요약 출력 — `.new` 파일은 `diff` 로 확인 후
+  수동 반영.
+
+## 사용법 2 — GitLab 템플릿
+
+새 프로젝트 생성 시 구성을 자동으로 깔리게 하는 법은 **[docs/GITLAB_TEMPLATE.md](GITLAB_TEMPLATE.md)** 참조.
+
+> 주의: self-hosted GitLab 기준. **CE** 는 네이티브 커스텀 프로젝트 템플릿(Premium)이 불가.
+> CE 에서는 **Import by URL + `bin/agents-scaffold.sh`**(B안) 또는 **스크립트 단독**(C안)을 쓴다.
+> 생성/주입 후 `bin/agents-scaffold.sh .` 1회 실행 → 스택 적용 + 치환 + `bin/`·`presets/`·`docs/superpowers/` self-clean.
+
+## 치환 플레이스홀더
+
+| 토큰 | 값 |
+|---|---|
+| `{{PROJECT_NAME}}` | `--name` 또는 대상 디렉터리명 |
+| `{{JAVA_VERSION}}` | `1.8` (springboot 프리셋 기본) |

--- a/docs/OPTIONS.zh.md
+++ b/docs/OPTIONS.zh.md
@@ -1,0 +1,173 @@
+# agents-scaffold — 全部选项
+
+`bin/agents-scaffold.sh` 的全部选项。概览请见 [README](../README.zh.md)。
+
+## 技术栈预设
+
+| 预设 | 规则文件 | pre-commit 门禁 |
+|--------|-----------|-----------------|
+| `nextjs` | nextjs.md (paths: app/**, components/**) | `tsc --noEmit` |
+| `springboot` | springboot.md (paths: src/main/java/**) | `./gradlew build` |
+| `javaweb` | javaweb.md (paths: src/main/java/**, **/*.jsp) | maven/gradle/ant compile（自动检测） |
+| `bun` | bun.md (paths: **/*.ts) | `bunx tsc --noEmit` |
+| `python` | python.md (paths: **/*.py) | `ruff check` + `mypy` |
+| `go` | go.md (paths: **/*.go) | `go build ./...` + `vet` + `golangci-lint` |
+| `rust` | rust.md (paths: src/**/*.rs, **/*.rs) | `cargo check` + `clippy` |
+| `android` | android.md (paths: **/*.kt) | `./gradlew ktlintCheck detekt` |
+| `flutter` | flutter.md (paths: **/*.dart, pubspec.yaml) | `dart format` + `flutter analyze` + `test` |
+| `ops` | ops.md (paths: Dockerfile, docker-compose*, quadlet/**, ansible/**) | — |
+
+## Forge 预设（`--forge`）
+
+注入与你所用 forge 匹配的 issue/PR 工作流。在技术栈预设之前合并。
+
+| 预设 | CLI | PR/MR | issue 关闭 |
+|--------|-----|-------|-------------|
+| `github`（默认） | `gh` | PR | 合并时通过 `Closes #N` **自动关闭** |
+| `gitlab` | `glab` | MR | `Closes #N` 自动关闭有效 —— 合并后需确认，仍处于 open 时才手动关闭 |
+
+注入的文件：`.claude/rules/forge.md`（始终加载），以及
+`.claude/commands/fix-issue.md` 和 `sdlc-cycle.md` 的 forge 变体（覆盖基础版本）。
+基础文件保持 forge 中立（"issue / PR·MR"）。
+
+## 挑选需求打磨工具
+
+实现之前打磨需求的手段有三种，**性质各不相同，按任务挑选**。内置的只有 `grill-me`，另外两个需单独安装。
+
+| | `grill-me` | superpowers | Ouroboros |
+|---|---|---|---|
+| **范围** | 仅拷问 | 覆盖整个工作流 | 拷问 → 规格 → 执行 → 评估 循环 |
+| **状态** | 止于对话之内 | 对话 + 文件产物 | 由 MCP 服务器持久管理 |
+| **重量** | 轻 | 中 | 重 — 每个问题都会 fanout 子代理 |
+| **安装** | **内置**（`.claude/skills/grill-me/`） | 插件 [obra/superpowers](https://github.com/obra/superpowers) | 市场 [Q00/ouroboros](https://github.com/Q00/ouroboros)（附带 MCP 服务器） |
+
+**选择标准**
+
+- 方向已定的功能，想找出规格中的漏洞 → **`grill-me`**。无需安装，一轮对话即可。
+- 一张白纸需要发散再收敛，并留下文档产物 → **superpowers 的 `brainstorming`**。
+- 需求模糊的大型工作，需要**先规格化，再以循环方式执行与评估** → **Ouroboros**。会话中断后状态仍在，但 token 成本三者中最高。
+
+按重量逐级升级，且**只向上走** — 轻量方案够用的任务上动用 Ouroboros 只会推高成本。三者即便都已安装也不会自动触发，由使用者按任务选定。
+
+## Harness（`--harness`）
+
+| 取值 | 目标 | 行为 |
+|---|---|---|
+| `claude`（默认） | Claude Code | 完整安装 — 含 settings.json 钩子绑定、子代理、斜杠命令、workflows |
+| `codex` | Codex 及其他 AGENTS.md harness | 仅安装与 harness 无关的层（AGENTS.md、rules、skills、hooks、memory），移除 Claude 专用层 |
+| `all` | 混合团队 | 完整安装 |
+
+**保障分为两级（#21）** — 不是"支持/不支持"的二分法。
+
+| 级别 | 成立的内容 | 适用 harness |
+|---|---|---|
+| **baseline** | `AGENTS.md` 正文中的 P0/P1（含所选技术栈的 P0）+ **真正的 `.git/hooks/pre-commit` 门禁** + CI | **全部 harness，与 `--harness` 取值无关。** 无论 harness 读取什么，也无论是否由人在终端直接提交，门禁都会生效 |
+| **full** | baseline + 该 harness 的原生层（子代理、skills、斜杠命令、按路径的条件加载、lifecycle 钩子） | 仅限适配器经过实测验证的 harness |
+
+git 钩子**与 harness 无关，始终接入**（#21）。Claude Code 的 `PreToolUse` 钩子只在该会话通过 Bash 工具提交时触发，因此它属于早期反馈层而非强制线 — 决定性的强制线放在 harness 之外（`.git/hooks` + CI）。已存在的 `.git/hooks/pre-commit` 不会被覆盖，只会给出警告。
+
+所选技术栈的 P0 会**直接插入 `AGENTS.md` 正文**，不依赖 `.claude/rules/` 引用链接，因此在不加载 `.claude/` 的 harness 上同样可达。未选择的技术栈不会被插入（Codex 指令合计默认上限为 32KiB — 以避免 context flooding）。
+
+### 实测验证（2026-08-22）
+
+| Harness | 实测版本 | baseline | full 层已确认 / 未确认的内容 |
+|---|---|---|---|
+| Claude Code | 2.1.239 | 成立 | `.claude/rules/*.md` 的 `paths:` 条件加载、子代理、skills、`settings.json` 钩子 — 均已对照[官方文档](https://code.claude.com/docs/en/memory.md)确认 |
+| Codex | codex-cli 0.149.0 | 成立 | 已实测 `AGENTS.md` 自动加载与依据 P0 拒绝 `.env`。**skills 不会被发现**（见下） |
+| Antigravity | agy **1.1.18**（未重测） | 成立 | 1.1.17 上实测 **headless（`-p`）不加载规则** — 原因未查明。1.1.18 与交互模式均未重测 |
+
+Codex（codex-cli 0.149.0）会自动加载 `codex` 模式产物中的 AGENTS.md，正确回答了规则分级，并**依据 P0 规则主动拒绝了提交 `.env` 的指令**（第一道防线）。即使模型执意尝试，git 钩子也会以 exit 2 拦截（第二道防线，已有测试覆盖）。
+
+**已知缺口 — Codex 的 skills 不会被自动发现。** Codex 发现仓库 skills 的路径是 `.agents/skills`，而当前 `--harness codex` 仍将其留在 `.claude/skills`。规则层（`AGENTS.md`）可用，skills 层不可用 — 这属于 baseline 而非 full。
+
+另有两项 Codex 约束影响设计：
+
+- **指令合计默认上限 32KiB**（`project_doc_max_bytes`），因此只把所选技术栈的 P0 内联进 `AGENTS.md`（`--stack javaweb` 实测 6,869 B — 占上限的 21%）。
+- **`.codex/` 层仅在项目受信任时加载。** 生成文件并不等于生效，因此决定性的强制线放在 `.git/hooks` + CI。
+
+## 语言（`--lang`）
+
+基础目录树（agents、rules、skills、commands、`AGENTS.md`、钩子/settings
+消息）**默认为韩语**（#36 反转——韩语是事实来源，英语是翻译出的覆盖层）。
+`--lang en` 会把英文翻译叠加在最上层，且最后应用——在基础复制、forge 预设、
+技术栈预设之后——用 `presets/lang-en/base` +
+`presets/lang-en/forge-<forge>` + `presets/lang-en/stacks/<stack>` 的内容
+覆盖同名文件。
+
+```bash
+agents-scaffold/bin/agents-scaffold.sh /path/to/new-repo --lang en --forge github --stack bun
+```
+
+`.claude/hooks/pre-commit.sh` 永远不会被 `--lang` 覆盖（它是技术栈片段
+拼接进去的文件——消息只有单一语言，代码不受语言影响）。`--update`
+只刷新韩语基础文件；若需要重新应用英文覆盖层，请在其后再带
+`--lang en` 运行一次。
+
+## Usage 1 — 脚本
+
+```bash
+git clone https://github.com/leeyudok/agents-scaffold.git
+# --forge 默认为 github；GitLab 仓库请用 --forge gitlab
+agents-scaffold/bin/agents-scaffold.sh /path/to/new-repo --forge github --stack nextjs,bun --name my-app
+```
+
+省略 `--forge`/`--stack`/`--name` 即进入交互模式——脚本会依次询问
+（forge 默认为 github）。
+
+### 选项
+
+| 选项 | 说明 |
+|---|---|
+| `<target-dir>` | 目标目录。默认 `.` |
+| `--forge <forge>` | `github`（默认）或 `gitlab` |
+| `--lang <lang>` | `ko`（默认）或 `en` |
+| `--stack <list>` | 逗号分隔的技术栈预设列表。省略时进入交互式提问 |
+| `--name <name>` | `{{PROJECT_NAME}}` 的替换值。默认 = 目标目录名 |
+| `--yes` | 跳过交互式提问（非交互模式） |
+| `--update` | 刷新已引导项目的基础文件（见下文） |
+
+### 远程一键安装（无需 clone）
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/leeyudok/agents-scaffold/main/bin/agents-scaffold.sh | bash -s -- --stack nextjs --yes
+```
+
+当脚本检测到自己并非从本地检出运行时（例如管道执行），会将
+`AGENTS_SCAFFOLD_REPO` 的 tarball（默认：
+`github.com/leeyudok/agents-scaffold`，可通过环境变量覆盖）下载到临时目录，
+并将其作为模板来源。用 `AGENTS_SCAFFOLD_REF` 固定分支/标签
+（默认 `main`）。
+
+### 更新基础文件 — `--update`
+
+将最新的基础文件（`.claude/`、`AGENTS.md`、`CLAUDE.md`、
+`GEMINI.md`）应用到已完成引导的项目。
+
+```bash
+agents-scaffold/bin/agents-scaffold.sh --update /path/to/existing-repo
+```
+
+- `.claude/hooks/pre-commit.sh` 始终被跳过——技术栈片段已被拼接
+  进去，需要手动合并。
+- 其他基础文件内容相同时跳过；有差异时保留现有文件，新版本写为
+  `<file>.new`（占位符替换同样作用于 `.new` 文件）。
+- 结束时打印新增 / 待更新 / 跳过 / 未变更文件的汇总——用 `diff`
+  查看 `.new` 文件后手动应用。
+
+## Usage 2 — GitLab 模板
+
+若想在创建新项目时自动应用这套配置，
+请参阅 **[docs/GITLAB_TEMPLATE.md](GITLAB_TEMPLATE.md)**。
+
+> 注意：该工作流假定使用自托管 GitLab 实例。在 **GitLab CE** 上，
+> 原生的自定义项目模板属于 Premium 功能、不可用——
+> 请改用 **Import by URL + `bin/agents-scaffold.sh`** 或**仅用脚本**。
+> 创建/导入后运行一次 `bin/agents-scaffold.sh .`，即可应用所选
+> 技术栈、替换占位符，并自清理 `bin/`/`presets/`/`docs/superpowers/`。
+
+## 占位符替换
+
+| 令牌 | 值 |
+|---|---|
+| `{{PROJECT_NAME}}` | `--name` 的值，或目标目录名 |
+| `{{JAVA_VERSION}}` | `1.8`（springboot 预设默认值） |


### PR DESCRIPTION
README 가 315줄 · 섹션 15개(그중 9개가 옵션 레퍼런스)라 첫 방문자용과 사용자용이 한 파일에 섞여 있었다. **내용은 하나도 버리지 않고 위치만** 옮긴다.

## 측정된 문제

| 항목 | 이전 |
|---|---|
| 길이 | 315줄 / 섹션 15개 |
| 첫 문단 자기 용어 | 5개 (fork-and-fill, P0/P1/P2, 스택 프리셋, pre-commit 게이트, 하네스) |
| 문제 진술 | **없음** |
| Before/After | **없음** (gif 는 설치 과정만) |

## 변경

- 첫 문단을 **가치 진술**로 교체 — 부정형 정의("프레임워크가 아니라")로 시작하지 않는다
- **"이런 적 있으면 이 도구다"** 통증 3항목 신설
- **"설치 직후 이런 일이 벌어진다"** 신설 — 지어낸 예시가 아니라 **실제 실행 출력**을 그대로 인용 (python 스택 부트스트랩 → `.env` 스테이징 → `Blocked: a .env-type file is staged.`)
- 옵션 8개 섹션 → `docs/OPTIONS.*.md`, 내부 구조 2개 섹션 → `docs/INTERNALS.*.md`
- 랜딩에 "더 보기" 표 추가

## 결과

- README **315줄 → 112줄**(ko)
- 이관된 실측치(하네스 매트릭스, 32KiB, trust boundary, 요구사항 도구 비교) **전부 보존**
- 다국어 동시: README 4종 + OPTIONS 4종 + INTERNALS 4종
- 이관으로 깨질 앵커 링크 수정, 링크 체커 **0 broken**, bats **39/39**

Closes #33