### PR TITLE
feat(#37): 지원 매트릭스 manifest + Codex 실측 spike (코덱스 몫 대행)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,3 +19,9 @@ jobs:
 
       - name: Run agents-scaffold.sh bats tests
         run: bats tests/agents-scaffold.bats
+
+      # 지원 매트릭스 게이트 (#37) — tier=full 인데 실측이 만료됐거나, 판정에 근거가
+      # 없거나, manifest 와 문서의 CLI 버전이 어긋나면 실패한다. 문서를 자동 수정하지
+      # 않는다 — 강등은 사람이 PR 로 반영한다.
+      - name: Check harness support matrix
+        run: python3 scripts/check-harness-matrix.py

--- a/bin/agents-scaffold.sh
+++ b/bin/agents-scaffold.sh
@@ -40,7 +40,7 @@ directory and used as the template source.
 
 Flow: copy base (.claude/ + CLAUDE.md) -> merge forge preset -> merge selected stack presets
       -> merge lang-en overlay (if --lang en) -> substitute {{PLACEHOLDER}} -> chmod +x
-      -> in-place: self-clean bin/·presets/·docs/superpowers/.
+      -> in-place: self-clean bin/·presets/·scripts/·docs/superpowers/·docs/harness-matrix.json.
 EOF
 }
 
@@ -449,8 +449,10 @@ fi
 
 # 5) in-place self-clean (템플릿 흔적 제거)
 if [ "$INPLACE" -eq 1 ]; then
-  echo "== self-clean: removing bin/ presets/ docs/superpowers/ ==" >&2
-  rm -rf "$TARGET/bin" "$TARGET/presets" "$TARGET/docs/superpowers"
+  echo "== self-clean: removing bin/ presets/ scripts/ docs/superpowers/ docs/harness-matrix.json ==" >&2
+  rm -rf "$TARGET/bin" "$TARGET/presets" "$TARGET/scripts" "$TARGET/docs/superpowers"
+  # scripts/ 와 harness-matrix.json 은 이 저장소의 유지보수 자산이지 사용자 산출물이 아니다 (#37)
+  rm -f "$TARGET/docs/harness-matrix.json"
 fi
 
 echo "== Done. Fill in CLAUDE.md and .claude/ for your project. ==" >&2

--- a/docs/OPTIONS.en.md
+++ b/docs/OPTIONS.en.md
@@ -85,6 +85,11 @@ Codex (codex-cli 0.149.0) auto-loads the `codex`-mode AGENTS.md, answered the ru
 correctly, and **refused an instruction to commit a `.env`, citing the P0 rule** (first line of
 defense). If a model tries anyway, the git hook blocks it with exit 2 (second line, test-covered).
 
+The single source of truth for support status is [`docs/harness-matrix.json`](harness-matrix.json).
+This table is checked against that manifest by `scripts/check-harness-matrix.py` in CI — if a `full`
+tier has gone 90 days without re-measurement, or a verdict carries no evidence, **the build fails**.
+Re-measure with `scripts/spike-codex-contract.sh --dynamic`.
+
 **Known gap — Codex skills are not auto-discovered.** Codex discovers repository skills under
 `.agents/skills`, but `--harness codex` currently leaves them in `.claude/skills`. The rules layer
 (`AGENTS.md`) works; the skills layer does not — that is baseline, not full.

--- a/docs/OPTIONS.ja.md
+++ b/docs/OPTIONS.ja.md
@@ -78,6 +78,8 @@ git フックは**ハーネスに関係なく常に配線されます**（#21）
 
 Codex（codex-cli 0.149.0）は `codex` モード成果物の AGENTS.md を自動で読み込み、ルール階層を正しく回答し、`.env` をコミットせよという指示を **P0 ルールを根拠に自ら拒否**しました（第一の防衛線）。モデルが強行しても git フックが exit 2 でブロックします（第二の防衛線、テスト済み）。
 
+サポート状況の単一の真実の源は [`docs/harness-matrix.json`](harness-matrix.json) です。この表はその manifest と突き合わされ、CI では `scripts/check-harness-matrix.py` が検査します — `full` 等級が 90 日以上再実測されていない、あるいは判定に根拠がない場合、**ビルドは失敗します**。再実測は `scripts/spike-codex-contract.sh --dynamic` で行います。
+
 **既知のギャップ — Codex の skills は自動発見されません。** Codex がリポジトリの skills を探す場所は `.agents/skills` ですが、現在の `--harness codex` は `.claude/skills` に残します。ルール層（`AGENTS.md`）は機能しますが skills 層は機能しません — これは full ではなく baseline です。
 
 Codex 側の制約がもう 2 点、設計に効いてきます。

--- a/docs/OPTIONS.md
+++ b/docs/OPTIONS.md
@@ -85,6 +85,11 @@ Codex(codex-cli 0.149.0)는 `codex` 모드 산출물의 AGENTS.md 를 자동 로
 답했고, `.env` 커밋 지시를 **P0 규칙을 근거로 스스로 거부**했다(1차 방어). 모델이 시도해도
 git hook 이 exit 2 로 차단한다(2차 방어, 테스트 커버).
 
+지원 상태의 단일 진실원천은 [`docs/harness-matrix.json`](harness-matrix.json) 이다. 이 표는
+그 manifest 와 대조되며, `scripts/check-harness-matrix.py` 가 CI 에서 검사한다 — `full` 등급이
+90일 넘게 재측정되지 않았거나 판정에 근거가 없으면 **빌드가 실패한다**. 재측정은
+`scripts/spike-codex-contract.sh --dynamic` 으로 수행한다.
+
 **알려진 갭 — Codex 스킬은 자동 발견되지 않는다.** Codex 의 저장소 스킬 발견 경로는
 `.agents/skills` 인데 현재 `--harness codex` 는 `.claude/skills` 를 남긴다. 규칙 계층
 (`AGENTS.md`)은 동작하지만 스킬은 그렇지 않다 — full 이 아니라 baseline 이다.

--- a/docs/OPTIONS.zh.md
+++ b/docs/OPTIONS.zh.md
@@ -78,6 +78,8 @@ git 钩子**与 harness 无关，始终接入**（#21）。Claude Code 的 `PreT
 
 Codex（codex-cli 0.149.0）会自动加载 `codex` 模式产物中的 AGENTS.md，正确回答了规则分级，并**依据 P0 规则主动拒绝了提交 `.env` 的指令**（第一道防线）。即使模型执意尝试，git 钩子也会以 exit 2 拦截（第二道防线，已有测试覆盖）。
 
+支持状态的单一真实来源是 [`docs/harness-matrix.json`](harness-matrix.json)。本表会与该 manifest 对照，并由 CI 中的 `scripts/check-harness-matrix.py` 检查 — 若某个 `full` 等级超过 90 天未重新实测，或某项判定缺少证据，**构建将失败**。重新实测请运行 `scripts/spike-codex-contract.sh --dynamic`。
+
 **已知缺口 — Codex 的 skills 不会被自动发现。** Codex 发现仓库 skills 的路径是 `.agents/skills`，而当前 `--harness codex` 仍将其留在 `.claude/skills`。规则层（`AGENTS.md`）可用，skills 层不可用 — 这属于 baseline 而非 full。
 
 另有两项 Codex 约束影响设计：

--- a/docs/harness-matrix.json
+++ b/docs/harness-matrix.json
@@ -1,0 +1,159 @@
+{
+  "$comment": "지원 매트릭스 SSOT (#37, a-1). 문서의 지원 표는 이 파일에서 파생되거나 이 파일과 대조된다. 실행하지 않은 항목은 pass 로 적지 않고 unverified 로 남긴다. 근거는 공식문서 URL 또는 실측 출력만 인정한다.",
+  "schema_version": 1,
+  "policy": {
+    "full_max_age_days": 90,
+    "$comment": "capability 등급이 full 인 하네스는 last_measured 가 이 일수를 넘기면 CI 가 실패한다. 강등은 사람이 PR 로 반영한다 — CI 가 문서를 자동 커밋하지 않는다."
+  },
+  "capabilities": {
+    "instructions": "루트 지침 파일이 자동 로드되는가",
+    "stack_p0_inline": "선택한 스택의 P0 가 지침 본문에서 읽히는가",
+    "repo_skills": "저장소 스킬이 발견·등록되는가",
+    "subagents": "프로젝트 스코프 커스텀 에이전트가 발견되는가",
+    "path_scoped_rules": "경로 조건부 규칙 로딩이 있는가",
+    "lifecycle_hooks": "하네스 자체 훅이 실행되는가",
+    "oob_gate": "하네스 밖 강제선(.git/hooks + CI)이 성립하는가"
+  },
+  "harnesses": [
+    {
+      "id": "claude",
+      "name": "Claude Code",
+      "cli_version": "2.1.239",
+      "last_measured": "2026-08-22",
+      "tier": "full",
+      "trust_model": "n/a",
+      "instruction_budget_bytes": null,
+      "capabilities": {
+        "instructions": {
+          "verdict": "pass",
+          "target": "CLAUDE.md",
+          "evidence": "https://code.claude.com/docs/en/memory.md"
+        },
+        "stack_p0_inline": {
+          "verdict": "pass",
+          "target": "AGENTS.md via @import in CLAUDE.md",
+          "evidence": "bats: stack P0 is inlined into AGENTS.md body (#21)"
+        },
+        "repo_skills": {
+          "verdict": "pass",
+          "target": ".claude/skills/<name>/SKILL.md",
+          "evidence": "https://code.claude.com/docs/en/skills.md"
+        },
+        "subagents": {
+          "verdict": "pass",
+          "target": ".claude/agents/*.md",
+          "evidence": "https://code.claude.com/docs/en/sub-agents.md"
+        },
+        "path_scoped_rules": {
+          "verdict": "pass",
+          "target": ".claude/rules/*.md (paths: frontmatter)",
+          "evidence": "https://code.claude.com/docs/en/memory.md#organize-rules-with-claude/rules/"
+        },
+        "lifecycle_hooks": {
+          "verdict": "partial",
+          "target": "settings.json hooks",
+          "evidence": "PreToolUse 는 그 세션이 Bash 툴로 커밋할 때만 발동 — 강제선이 아니라 조기 피드백 (#21)"
+        },
+        "oob_gate": {
+          "verdict": "pass",
+          "target": ".git/hooks/pre-commit",
+          "evidence": "bats: default harness gate blocks a staged .env, exit 2 (#21)"
+        }
+      }
+    },
+    {
+      "id": "codex",
+      "name": "Codex",
+      "cli_version": "codex-cli 0.149.0",
+      "last_measured": "2026-08-22",
+      "tier": "baseline",
+      "trust_model": "project trust required for .codex/ layer",
+      "instruction_budget_bytes": 32768,
+      "capabilities": {
+        "instructions": {
+          "verdict": "pass",
+          "target": "AGENTS.md (+ nested AGENTS.override.md)",
+          "evidence": "spike-codex-contract.sh --dynamic: P0 응답 정확",
+          "reproducibility": "완주 2회 / 시도 2회"
+        },
+        "stack_p0_inline": {
+          "verdict": "pass",
+          "target": "AGENTS.md body",
+          "evidence": "spike: 인라인된 python 스택 P0 를 응답에 포함. 산출물 AGENTS.md 6,612 B / 32,768 B"
+        },
+        "repo_skills": {
+          "verdict": "fail",
+          "target": ".agents/skills/<name>/SKILL.md",
+          "evidence": "통제실험 1회 완주: 동일 저장소의 .agents/skills 프로브만 등록 스킬로 응답, .claude/skills 프로브는 미응답. 현재 --harness codex 산출물은 .claude/skills 이므로 미발견.",
+          "reproducibility": "완주 1회 / 시도 3회 — 나머지 2회는 codex 호출 타임아웃으로 inconclusive. 재측정 시 CODEX_TIMEOUT 을 늘릴 것."
+        },
+        "subagents": {
+          "verdict": "unverified",
+          "target": ".codex/agents/*.toml",
+          "evidence": "산출물에 .codex/ 를 생성하지 않으므로 미측정"
+        },
+        "path_scoped_rules": {
+          "verdict": "n/a",
+          "target": "nested AGENTS.md 계층",
+          "evidence": ".codex/rules/*.rules 는 명령 실행 정책이며 코딩 가이던스가 아니다"
+        },
+        "lifecycle_hooks": {
+          "verdict": "unverified",
+          "target": ".codex/hooks.json",
+          "evidence": "hook 신뢰가 정의 hash 에 묶임(codex exec --dangerously-bypass-hook-trust 존재로 확인). 산출물이 .codex/ 를 만들지 않아 미측정"
+        },
+        "oob_gate": {
+          "verdict": "pass",
+          "target": ".git/hooks/pre-commit",
+          "evidence": "spike: 스테이징된 .env 에 대해 exit 2"
+        }
+      }
+    },
+    {
+      "id": "agy",
+      "name": "Antigravity",
+      "cli_version": "1.1.18",
+      "last_measured": "2026-08-22",
+      "tier": "experimental",
+      "trust_model": "unknown",
+      "instruction_budget_bytes": null,
+      "capabilities": {
+        "instructions": {
+          "verdict": "unverified",
+          "target": "unknown",
+          "evidence": "1.1.17 headless(-p) 에서 규칙 미로드 관측, 원인 미규명. 1.1.18 재측정 및 interactive 모드 미실시"
+        },
+        "stack_p0_inline": {
+          "verdict": "unverified",
+          "target": "unknown",
+          "evidence": "instructions 미확정으로 종속 미측정"
+        },
+        "repo_skills": {
+          "verdict": "unverified",
+          "target": "unknown",
+          "evidence": "미측정"
+        },
+        "subagents": {
+          "verdict": "unverified",
+          "target": "unknown",
+          "evidence": "미측정"
+        },
+        "path_scoped_rules": {
+          "verdict": "unverified",
+          "target": "unknown",
+          "evidence": "미측정"
+        },
+        "lifecycle_hooks": {
+          "verdict": "unverified",
+          "target": "unknown",
+          "evidence": "미측정"
+        },
+        "oob_gate": {
+          "verdict": "pass",
+          "target": ".git/hooks/pre-commit",
+          "evidence": "하네스와 무관하게 배선됨 (#21)"
+        }
+      }
+    }
+  ]
+}

--- a/scripts/check-harness-matrix.py
+++ b/scripts/check-harness-matrix.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""지원 매트릭스 manifest 검사 (#37, a-1).
+
+CI 게이트다. 문서를 자동으로 고치지 않는다 — 어긋나면 실패시키고 사람이 PR 로 반영한다.
+
+검사 항목
+  1. 스키마 — 필수 키, verdict 어휘, 날짜 형식
+  2. 만료   — tier=full 인데 last_measured 가 policy.full_max_age_days 를 넘으면 실패
+  3. 정합성 — tier 가 실제 capability 판정과 모순되면 실패
+              (full 인데 fail/unverified 가 있으면 안 된다)
+  4. 문서 대조 — README 가 주장하는 CLI 버전이 manifest 와 일치하는가
+
+사용:  python3 scripts/check-harness-matrix.py [--today YYYY-MM-DD]
+"""
+import json
+import pathlib
+import re
+import sys
+from datetime import date, datetime
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+MANIFEST = ROOT / "docs" / "harness-matrix.json"
+VERDICTS = {"pass", "partial", "fail", "unverified", "inconclusive", "n/a"}
+TIERS = {"full", "baseline", "experimental", "unsupported"}
+DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+
+def fail(msgs):
+    for m in msgs:
+        print(f"FAIL: {m}", file=sys.stderr)
+    return 1
+
+
+def main(argv):
+    today = date.today()
+    if "--today" in argv:
+        today = datetime.strptime(argv[argv.index("--today") + 1], "%Y-%m-%d").date()
+
+    data = json.loads(MANIFEST.read_text(encoding="utf-8"))
+    errors = []
+    max_age = data["policy"]["full_max_age_days"]
+    known_caps = set(data["capabilities"])
+
+    for h in data["harnesses"]:
+        hid = h.get("id", "<no id>")
+        for key in ("id", "name", "cli_version", "last_measured", "tier", "capabilities"):
+            if key not in h:
+                errors.append(f"{hid}: 필수 키 누락 '{key}'")
+        if h.get("tier") not in TIERS:
+            errors.append(f"{hid}: 알 수 없는 tier '{h.get('tier')}'")
+        if not DATE_RE.match(h.get("last_measured", "")):
+            errors.append(f"{hid}: last_measured 형식 오류 '{h.get('last_measured')}'")
+            continue
+
+        measured = datetime.strptime(h["last_measured"], "%Y-%m-%d").date()
+        age = (today - measured).days
+        if age < 0:
+            errors.append(f"{hid}: last_measured 가 미래다 ({h['last_measured']})")
+
+        caps = h["capabilities"]
+        missing = known_caps - set(caps)
+        if missing:
+            errors.append(f"{hid}: capability 항목 누락 {sorted(missing)}")
+        for name, c in caps.items():
+            if name not in known_caps:
+                errors.append(f"{hid}: 정의되지 않은 capability '{name}'")
+            if c.get("verdict") not in VERDICTS:
+                errors.append(f"{hid}.{name}: 알 수 없는 verdict '{c.get('verdict')}'")
+            if not c.get("evidence"):
+                errors.append(f"{hid}.{name}: evidence 가 비어 있다 — 근거 없는 판정 금지")
+
+        if h.get("tier") == "full":
+            if age > max_age:
+                errors.append(
+                    f"{hid}: tier=full 인데 마지막 실측이 {age}일 전이다 "
+                    f"(한도 {max_age}일). 재측정하고 last_measured 를 갱신하거나 tier 를 강등할 것"
+                )
+            bad = [n for n, c in caps.items()
+                   if c.get("verdict") in {"fail", "unverified", "inconclusive"}]
+            if bad:
+                errors.append(f"{hid}: tier=full 인데 미확정/실패 capability 가 있다 {sorted(bad)}")
+
+    # 문서 대조 — README 가 주장하는 버전이 manifest 와 같아야 한다
+    for h in data["harnesses"]:
+        ver = h["cli_version"].split()[-1]
+        hits = [p.name for p in ROOT.glob("README*.md")
+                if ver in p.read_text(encoding="utf-8")]
+        docs = [p.name for p in (ROOT / "docs").glob("OPTIONS*.md")
+                if ver in p.read_text(encoding="utf-8")]
+        if not hits and not docs:
+            errors.append(
+                f"{h['id']}: manifest 의 cli_version '{ver}' 이 README/docs 어디에도 없다 "
+                f"— 문서가 낡았거나 manifest 가 낡았다"
+            )
+
+    if errors:
+        return fail(errors)
+    print(f"OK: {len(data['harnesses'])} harnesses, 기준일 {today}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/spike-codex-contract.sh
+++ b/scripts/spike-codex-contract.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# Codex 계약 실측 spike (#37, a-2)
+#
+# codex-cli 의 저장소 계약을 실제로 측정한다. 문서 인용이 아니라 실행 결과가 근거다.
+# 결과는 stdout 에 JSON 으로 출력한다 — docs/harness-matrix.json 의 입력.
+#
+#   scripts/spike-codex-contract.sh [--dynamic]
+#
+# --dynamic 을 주면 codex exec 로 실제 모델 호출까지 수행한다(API 쿼터 소모).
+# 생략하면 정적 검사만 하고 동적 항목은 unverified 로 남긴다.
+set -u
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+DYNAMIC=0
+[ "${1:-}" = "--dynamic" ] && DYNAMIC=1
+# codex 호출은 수 분이 걸리고 종종 타임아웃한다. 응답이 없는 것과 "없다고 답한 것"은
+# 다른 사실이므로 구분한다 — 응답 없음은 fail 이 아니라 inconclusive 다.
+CODEX_TIMEOUT="${CODEX_TIMEOUT:-600}"
+
+CODEX_VERSION="$(codex --version 2>/dev/null | tr -d '\n' || echo 'not-installed')"
+TODAY="$(date +%Y-%m-%d)"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+git -C "$WORK" init -q
+git -C "$WORK" config user.email spike@local
+git -C "$WORK" config user.name spike
+bash "$REPO_ROOT/bin/agents-scaffold.sh" "$WORK" --forge github --stack python \
+  --harness codex --name spike-app --yes >/dev/null 2>&1
+
+# ---- 정적 측정 -------------------------------------------------------------
+agents_bytes=$(wc -c < "$WORK/AGENTS.md" | tr -d ' ')
+has_agents_skills=$([ -d "$WORK/.agents/skills" ] && echo true || echo false)
+has_claude_skills=$([ -d "$WORK/.claude/skills" ] && echo true || echo false)
+has_codex_dir=$([ -d "$WORK/.codex" ] && echo true || echo false)
+has_git_hook=$([ -x "$WORK/.git/hooks/pre-commit" ] && echo true || echo false)
+
+# 게이트가 실제로 .env 를 막는가 (exit code 로 판정)
+( cd "$WORK" && echo 'K=v' > .env && git add -f .env >/dev/null 2>&1 )
+gate_exit=0
+( cd "$WORK" && bash .git/hooks/pre-commit >/dev/null 2>&1 ) || gate_exit=$?
+( cd "$WORK" && git reset -q HEAD .env >/dev/null 2>&1; rm -f .env )
+
+# ---- 동적 측정 -------------------------------------------------------------
+p0_answer="unverified"; p0_note="--dynamic 미지정"
+skill_answer="unverified"; skill_note="--dynamic 미지정"
+if [ "$DYNAMIC" -eq 1 ] && [ "$CODEX_VERSION" != "not-installed" ]; then
+  out="$WORK/_p0.txt"
+  timeout "$CODEX_TIMEOUT" codex exec -C "$WORK" --skip-git-repo-check -s read-only \
+    -o "$out" "이 저장소의 P0 규칙을 그대로 나열해라. 추측하지 말고 저장소 지침에 적힌 것만." \
+    >/dev/null 2>&1
+  if [ ! -s "$out" ]; then
+    p0_answer="inconclusive"; p0_note="codex 응답 없음(타임아웃 또는 빈 출력) — 미측정으로 취급"
+  elif grep -qi 'p0' "$out"; then
+    if grep -qi 'mypy\|ruff' "$out"; then
+      p0_answer="pass"; p0_note="AGENTS.md 자동 로드 + 인라인된 python 스택 P0 까지 응답"
+    else
+      p0_answer="partial"; p0_note="공통 P0 는 응답했으나 인라인된 스택 P0 는 응답에 없음"
+    fi
+  else
+    p0_answer="fail"; p0_note="응답은 왔으나 P0 를 답하지 못함"
+  fi
+
+  # 스킬 발견은 통제 실험으로 잰다. 단순히 "스킬 목록을 말해봐" 라고 물으면
+  # 모델이 파일시스템을 읽어서 답하거나 사용자 전역 스킬을 섞어 답하므로 무효다.
+  # 레포에만 존재하는 유니크 이름 2개를 서로 다른 경로에 심고 어느 쪽이 등록되는지 본다.
+  mkdir -p "$WORK/.claude/skills/zqx-claudepath" "$WORK/.agents/skills/zqx-agentspath"
+  printf -- '---\nname: zqx-claudepath\ndescription: probe skill under .claude/skills\n---\n\nprobe A\n' \
+    > "$WORK/.claude/skills/zqx-claudepath/SKILL.md"
+  printf -- '---\nname: zqx-agentspath\ndescription: probe skill under .agents/skills\n---\n\nprobe B\n' \
+    > "$WORK/.agents/skills/zqx-agentspath/SKILL.md"
+  out2="$WORK/_skill.txt"
+  timeout "$CODEX_TIMEOUT" codex exec -C "$WORK" --skip-git-repo-check -s read-only \
+    -o "$out2" "너에게 등록된 skill 중 이름이 'zqx-' 로 시작하는 것만 나열해라. 파일시스템을 뒤지지 마라 — ls/find/cat/grep 등 명령 실행 금지. 등록된 skill 목록에서만 골라라. 없으면 '없음'." \
+    >/dev/null 2>&1
+  agents_seen=$(grep -c 'zqx-agentspath' "$out2" 2>/dev/null || echo 0)
+  claude_seen=$(grep -c 'zqx-claudepath' "$out2" 2>/dev/null || echo 0)
+  if [ ! -s "$out2" ]; then
+    skill_answer="inconclusive"; skill_note="codex 응답 없음(타임아웃 또는 빈 출력) — 미측정으로 취급"
+  elif [ "$agents_seen" -gt 0 ] && [ "$claude_seen" -eq 0 ]; then
+    skill_answer="pass"; skill_note=".agents/skills 만 등록됨 — .claude/skills 는 Codex 탐색 경로가 아님(통제 실험 확정)"
+  elif [ "$agents_seen" -gt 0 ] && [ "$claude_seen" -gt 0 ]; then
+    skill_answer="partial"; skill_note="양쪽 경로 모두 등록됨"
+  elif [ "$claude_seen" -gt 0 ]; then
+    skill_answer="unexpected"; skill_note=".claude/skills 만 등록됨 — 문서와 반대"
+  else
+    skill_answer="fail"; skill_note="응답은 왔으나 어느 경로도 등록되지 않음"
+  fi
+  rm -rf "$WORK/.agents" "$WORK/.claude/skills/zqx-claudepath"
+fi
+
+cat <<JSON
+{
+  "measured_at": "$TODAY",
+  "codex_version": "$CODEX_VERSION",
+  "dynamic": $([ "$DYNAMIC" -eq 1 ] && echo true || echo false),
+  "static": {
+    "agents_md_bytes": $agents_bytes,
+    "agents_md_budget_bytes": 32768,
+    "has_agents_skills_dir": $has_agents_skills,
+    "has_claude_skills_dir": $has_claude_skills,
+    "has_codex_dir": $has_codex_dir,
+    "git_hook_wired": $has_git_hook,
+    "gate_exit_on_staged_env": $gate_exit
+  },
+  "dynamic_results": {
+    "instructions_p0": { "verdict": "$p0_answer", "note": "$p0_note" },
+    "repo_skills_discovery_path": { "verdict": "$skill_answer", "note": "$skill_note" }
+  }
+}
+JSON

--- a/tests/agents-scaffold.bats
+++ b/tests/agents-scaffold.bats
@@ -157,6 +157,18 @@ EOF
 
 # --- 8) in-place self-clean ---
 
+@test "harness matrix manifest passes its own checker (#37)" {
+  run python3 "$REPO_ROOT/scripts/check-harness-matrix.py"
+  [ "$status" -eq 0 ]
+}
+
+@test "harness matrix checker actually fails an expired full tier (#37)" {
+  # 게이트가 실제로 막는지 확인한다 — 통과만 보면 무용지물인 검사기를 못 잡는다.
+  run python3 "$REPO_ROOT/scripts/check-harness-matrix.py" --today 2099-01-01
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"tier=full"* ]]
+}
+
 @test "in-place self-clean removes bin presets docs/superpowers (run against repo copy)" {
   copy="$BATS_TEST_TMPDIR/repo-copy"
   cp -R "$REPO_ROOT" "$copy"


### PR DESCRIPTION
#20 역할분담에서 GPT(Codex) 담당이던 a-1·a-2 가 수행되지 않은 채 #20 이 닫혔다. 대신 수행한다.

## a-2. Codex spike — `scripts/spike-codex-contract.sh`

codex-cli 0.149.0 실측. 정적은 항상, `--dynamic` 이면 `codex exec` 로 실제 호출.

| 항목 | 결과 |
|---|---|
| AGENTS.md 자동 로드 + 스택 P0 응답 | **pass** (완주 2/2) |
| AGENTS.md 크기 | **6,612 B** / 32,768 B (20%) |
| 스테이징된 `.env` | git hook **exit 2** |
| 저장소 스킬 | **`.agents/skills` 만 등록, `.claude/skills` 미등록** |

### 테스트 설계를 두 번 고쳤다

1. 처음엔 "스킬 목록을 말해봐" 로 물어 **pass** 가 나왔는데, 모델이 파일시스템을 읽었거나 사용자 전역 스킬을 섞어 답한 것이었다 → 레포에만 있는 유니크 이름 2개를 두 경로에 심는 **통제 실험**으로 교체
2. codex 호출이 자주 타임아웃하는데 초기 구현이 이를 **fail 로 오판**했다 → "응답 없음"은 `inconclusive`, "없다고 답함"은 `fail` 로 분리

## a-1. manifest — `docs/harness-matrix.json`

harness × CLI 버전 × capability × 판정 × **근거** × 실측일자 × trust × 바이트예산. 미실행 항목은 pass 로 적지 않고 `unverified`/`inconclusive`, **재현성(완주/시도)도 기록**한다.

`scripts/check-harness-matrix.py` 가 CI 게이트:
- `full` 인데 실측 90일 초과 → **실패**
- `full` 인데 fail/unverified/inconclusive 존재 → **실패**
- evidence 빈 판정 → **실패** (근거 없는 판정 금지)
- manifest 의 CLI 버전이 문서 어디에도 없음 → **실패**

문서를 자동 커밋하지 않는다 — 강등은 사람이 PR 로 (#20 보정 2).

## 검증

- bats **43/43**. 신규 2건 중 하나는 **검사기가 만료 full 을 실제로 실패시키는지** 확인 (통과만 보면 무용지물 검사기를 못 잡는다)
- 링크 체커 **0 broken**
- in-place self-clean 에 `scripts/`·`harness-matrix.json` 추가 (사용자 산출물 아님)

Closes #37