### PR TITLE
feat(#39): /status 에 사용량(ccusage) 옵셔널 표시 추가

### DIFF
--- a/.claude/skills/status/SKILL.md
+++ b/.claude/skills/status/SKILL.md
@@ -49,6 +49,14 @@ command -v glab >/dev/null && glab issue list --state=opened -P 1 --per-page 5 2
 command -v pm2 >/dev/null && pm2 list 2>/dev/null | head -20 || true
 ```
 
+### 6. 오늘 사용량 (옵션 — `ccusage` 가 있을 때만)
+```bash
+# ccusage 는 Claude Code 전용 사용량 도구다. 설치돼 있지 않으면 조용히 건너뛴다
+# (Codex·agy 등 다른 하네스에서는 해당 없음).
+command -v ccusage >/dev/null && ccusage daily --since "$(date +%Y%m%d)" --json 2>/dev/null \
+  | python3 -c "import json,sys; d=json.load(sys.stdin).get('daily') or [{}]; r=d[0]; print(f\"오늘 {r.get('totalTokens',0):,} 토큰 / \${r.get('totalCost',0):.2f}\")" 2>/dev/null || true
+```
+
 ## 출력 형식
 
 ```
@@ -66,6 +74,9 @@ TypeScript: ✅ 에러 없음 / ❌ N개 에러
 ### 이슈 (오픈)
 #42 [feature] ...
 #38 [bug] ...
+
+### 사용량 (ccusage 있을 때만)
+오늘 1,207,480,323 토큰 / $1227.00
 
 ### 다음 할 일
 - (현재 브랜치 기준 TODO 코멘트나 남은 작업)

--- a/presets/lang-en/base/.claude/skills/status/SKILL.md
+++ b/presets/lang-en/base/.claude/skills/status/SKILL.md
@@ -49,6 +49,14 @@ command -v glab >/dev/null && glab issue list --state=opened -P 1 --per-page 5 2
 command -v pm2 >/dev/null && pm2 list 2>/dev/null | head -20 || true
 ```
 
+### 6. Today's usage (optional — only when `ccusage` is present)
+```bash
+# ccusage reports Claude Code usage. If it isn't installed, skip silently
+# (it does not apply to other harnesses such as Codex or agy).
+command -v ccusage >/dev/null && ccusage daily --since "$(date +%Y%m%d)" --json 2>/dev/null \
+  | python3 -c "import json,sys; d=json.load(sys.stdin).get('daily') or [{}]; r=d[0]; print(f\"today {r.get('totalTokens',0):,} tokens / \${r.get('totalCost',0):.2f}\")" 2>/dev/null || true
+```
+
 ## Output format
 
 ```
@@ -66,6 +74,9 @@ Build: ✅ succeeded / ❌ failed
 ### Issues (open)
 #42 [feature] ...
 #38 [bug] ...
+
+### Usage (only when ccusage is present)
+today 1,207,480,323 tokens / $1227.00
 
 ### Next steps
 - (remaining TODO comments or outstanding work on the current branch)


### PR DESCRIPTION
스캐폴드에 비용 관측 수단이 전혀 없었다(`ccusage` 문자열 **0건**). P0/P1 로 품질은 게이트하면서 **토큰 비용은 무방비**였다.

## 설계

독립 스킬을 새로 만들지 않고 기존 `/status` 에 **절 하나**로 붙인다. `ccusage` 는 Claude Code 전용이고 이 스캐폴드는 하네스 중립을 지향하므로(Codex·agy 사용자에겐 무의미), `command -v` 로 가드해 **있을 때만 출력하고 없으면 조용히 건너뛴다.**

## 검증

| 환경 | 결과 |
|---|---|
| ccusage 설치됨 | `오늘 1,225,931,478 토큰 / $1241.65` 한 줄 |
| `PATH=/usr/bin:/bin` (미설치) | **아무 출력도 에러도 없음** |

ko/en 동시 갱신. bats 43/43, 링크 체커 0 broken, harness-matrix 검사 OK.

Closes #39