### PR TITLE
fix: skip gitignored user_*.md targets in link check (#41)

### DIFF
--- a/.claude/scripts/knowledge_graph.py
+++ b/.claude/scripts/knowledge_graph.py
@@ -36,6 +36,7 @@ ROOT_DOCS = [("AGENTS.md", "root"), ("CLAUDE.md", "root")]
 MD_LINK = re.compile(r"\[([^\]]*)\]\(([^)\s]+)\)")
 WIKI_LINK = re.compile(r"\[\[([a-z0-9-]+)\]\]")
 ISSUE_REF = re.compile(r"#(\d{2,4})\b")
+PERSONAL_MEMORY = re.compile(r"^user_.*\.md$")  # gitignored per-developer memory
 FRONT_NAME = re.compile(r"^name:\s*(\S+)", re.M)
 FRONT_DESC = re.compile(r"^description:\s*(.+)$", re.M)
 
@@ -120,6 +121,10 @@ def build_graph():
                 edges.append({"from": path, "to": resolved, "kind": "link"})
             elif os.path.exists(os.path.join(REPO, resolved)):
                 continue  # a real file outside the graph (code etc.) — skip, no node
+            elif PERSONAL_MEMORY.match(os.path.basename(resolved)):
+                # user_*.md is gitignored per-developer memory (see .claude/.gitignore).
+                # MEMORY.md links to it legitimately; its absence is by design, not breakage.
+                continue
             else:
                 broken.append({"from": path, "target": target})
 

--- a/tests/test_knowledge_graph.py
+++ b/tests/test_knowledge_graph.py
@@ -72,6 +72,21 @@ class TestLinks(FixtureCase):
         self.assertEqual(broken, [])
         self.assertEqual([e for e in edges if e["kind"] == "link"], [])
 
+    def test_gitignored_personal_memory_is_not_broken(self):
+        # user_*.md 는 .claude/.gitignore 로 제외되는 개인 메모리다. MEMORY.md 가 링크하는 것이
+        # 정상이고 파일 부재도 설계상 정상이므로 broken 으로 잡히면 안 된다.
+        write(self.repo, ".claude/memory/MEMORY.md", "[내 머신](user_this-machine.md)")
+        nodes, edges, broken = self.graph()
+        self.assertEqual(broken, [])
+        self.assertEqual([e for e in edges if e["kind"] == "link"], [])
+
+    def test_missing_non_personal_memory_is_still_broken(self):
+        # 위 예외가 일반 메모리까지 삼키면 안 된다.
+        write(self.repo, ".claude/memory/MEMORY.md", "[없는 것](project_nope.md)")
+        nodes, edges, broken = self.graph()
+        self.assertEqual(len(broken), 1)
+        self.assertEqual(broken[0]["target"], "project_nope.md")
+
     def test_links_inside_code_fence_and_inline_code_are_ignored(self):
         write(
             self.repo, ".claude/rules/common.md",


### PR DESCRIPTION
Fixes #41.

## Problem

`user_*.md` is per-developer memory excluded by `.claude/.gitignore`. `MEMORY.md` links to it legitimately, and its absence in a fresh clone or a git worktree is **by design** — but the link checker reported those as broken:

```
broken links: 2
  MEMORY.md -> user_this-machine-pnpm-no-node.md
  MEMORY.md -> user_this-machine-is-pig.md
```

That makes the "0 broken links" signal unusable. A checker that always fails gets ignored, and real breakage hides in the noise.

## Change

Skip targets matching `user_*.md` in the resolver, alongside the existing "real file outside the graph" branch. Everything else still gets reported.

## Tests

Two cases added to `tests/test_knowledge_graph.py`:

- `test_gitignored_personal_memory_is_not_broken` — the reported case
- `test_missing_non_personal_memory_is_still_broken` — guards against the exception swallowing ordinary memory links

```
$ python3 -m unittest discover -s tests
Ran 24 tests in 0.088s
OK
```

Verified downstream on a repo using this scaffold: `98 nodes / 128 edges / 0 broken links` (previously 2 false positives).
