### PR TITLE
fix: mask URL-inline credentials in observation log (#42)

### DIFF
--- a/.claude/hooks/observe-lite.sh
+++ b/.claude/hooks/observe-lite.sh
@@ -37,6 +37,11 @@ if tool == "Bash":
 else:
     summary = str(ti.get("file_path", ti.get("pattern", "")))[:200]
 
+# URL 인라인 자격증명 — postgres://user:pw@host 형태. 아래 key=value 정규식은 키 이름이
+# 앞에 없는 이 형태를 잡지 못하므로 먼저 지운다. 수량자는 아래와 같이 상한을 둔다.
+summary = re.sub(r"([a-zA-Z][a-zA-Z0-9+.\-]{1,15}://)[^:/@\s]{1,64}:[^@/\s]{1,128}@",
+                 r"\1[REDACTED]@", summary)
+
 # 시크릿 마스킹 (bounded, 재앙적 백트래킹 방지)
 summary = re.sub(
     r"(?i)(api[_-]?key|token|secret|password|authorization|auth)"


### PR DESCRIPTION
Fixes #42.

## Problem

The masking step in `observe-lite.sh` only covers **`key = value`** shapes (`api_key`, `token`, `password`, …). Credentials embedded in a URL have **no key name in front of them**, so they pass through untouched:

```
psql postgres://appuser:S3cretPw@db.example.com:5432/mydb
git remote add o https://tok:ghp_AAAABBBBCCCCDDDD@github.com/x/y.git
```

Both were recorded verbatim in `.claude/memory/observations/<session>.jsonl`.

The log is gitignored, so this is not a commit leak — but it is a **durable local plaintext store of secrets, written automatically on every Bash call**, which is the opposite of what the masking step exists to guarantee. Any project handling DSNs, AMQP URLs, or git remotes with embedded tokens accumulates them.

## Change

Strip `scheme://user:pw@` before the existing key=value pass. Quantifiers are bounded, consistent with the existing "재앙적 백트래킹 방지" note. Host, port and path are preserved so the log stays useful for diagnostics.

## Verified

```
$ printf '%s' '{"session_id":"prtest","tool_name":"Bash","tool_input":{"command":
  "psql postgres://appuser:S3cretPw@db.example.com:5432/mydb -c \"select 1\"
   && export API_KEY=abcdef1234567890
   && git remote add o https://tok:ghp_AAAABBBBCCCCDDDD@github.com/x/y.git"}}' \
  | ./.claude/hooks/observe-lite.sh

$ cat .claude/memory/observations/prtest.jsonl
{"ts": "...", "tool": "Bash", "summary":
 "psql postgres://[REDACTED]@db.example.com:5432/mydb -c \"select 1\"
  && export API_KEY=[REDACTED]
  && git remote add o https://[REDACTED]@github.com/x/y.git", "err": false}
```

All three forms redacted. Existing suite unaffected: `Ran 22 tests ... OK`.
